### PR TITLE
chore: rebrand to Mr. Overkill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,21 +1,21 @@
-## 브랜치 규칙
+## Branch Rules
 
-develop 브랜치 외에서 작업할떄는 항상 커밋/푸시 해서 작업을 종료할것.
+Always commit and push before ending work on any branch other than develop.
 
-## 커밋 메시지
+## Commit Messages
 
-기계적인 나열 대신, **왜 이 변경이 필요한지** 의도를 담아 쓸 것.
+Instead of mechanical listings, convey **why the change is needed**.
 
-나쁜 예:
+Bad examples:
 - `fix(review-loop): eliminate temp file leak and unify error-code handling`
 - `fix(review-loop): distinguish file-not-found from parse error, remove global pollution`
 
-좋은 예:
-- `fix: 조기 종료 시 temp 파일이 남는 문제 해결`
-- `fix: Codex 실패와 JSON 파싱 실패를 구분할 수 있도록 exit code 분리`
-- `refactor: 메인 루프가 400줄 넘어 읽기 어려워서 헬퍼 함수로 분리`
+Good examples:
+- `fix: resolve temp file leak on early exit`
+- `fix: separate exit codes so Codex failure and JSON parse failure are distinguishable`
+- `refactor: extract helper functions because main loop exceeded 400 lines`
 
-원칙:
-- 제목은 한국어로, 변경의 동기/맥락을 담는다
-- conventional commit prefix (fix, feat, refactor 등)는 유지
-- 본문이 필요하면 빈 줄 후 상세 설명 추가
+Principles:
+- Write the subject in English, capturing the motivation/context of the change
+- Keep conventional commit prefixes (fix, feat, refactor, etc.)
+- Add a detailed body after a blank line if needed

--- a/README.md
+++ b/README.md
@@ -1,33 +1,33 @@
-# Codex-Claude Review-Fix Loop
+# Mr. Overkill
 
-Codex(reviewer) and Claude(developer) collaborate to automatically improve code quality through an iterative review-fix loop.
+> Codex(reviewer) × Claude(developer) — AI agents collaborate through an iterative review-fix loop to automatically improve your code. Yes, it's overkill. That's the point.
 
 ## Quick Install
 
 ```bash
 # Install into your project
-git clone --depth 1 https://github.com/modocai/review_collaboration.git /tmp/review_collaboration \
-  && /tmp/review_collaboration/install.sh /path/to/your-project \
-  && rm -rf /tmp/review_collaboration
+git clone --depth 1 https://github.com/modocai/mr-overkill.git /tmp/mr-overkill \
+  && /tmp/mr-overkill/install.sh /path/to/your-project \
+  && rm -rf /tmp/mr-overkill
 ```
 
 Or clone and install manually:
 
 ```bash
-git clone https://github.com/modocai/review_collaboration.git
-./review_collaboration/install.sh /path/to/your-project
+git clone https://github.com/modocai/mr-overkill.git
+./mr-overkill/install.sh /path/to/your-project
 ```
 
 ## Prerequisites
 
 **Accounts**:
 
-- [OpenAI](https://platform.openai.com/) account (paid plan) — Codex CLI 사용에 필요
-- [Anthropic](https://console.anthropic.com/) account (Pro/Max plan 또는 API credits) — Claude Code CLI 사용에 필요
+- [OpenAI](https://platform.openai.com/) account (paid plan) — required for Codex CLI
+- [Anthropic](https://console.anthropic.com/) account (Pro/Max plan or API credits) — required for Claude Code CLI
 
 **Runtime**:
 
-- [Node.js](https://nodejs.org/) v18+ — Codex, Claude Code CLI 실행에 필요
+- [Node.js](https://nodejs.org/) v18+ — required to run Codex and Claude Code CLI
 
 **CLI Tools**:
 


### PR DESCRIPTION
## Summary
- Rename repo `review_collaboration` → `mr-overkill`
- README/AGENTS.md translated to English
- Commit message convention switched to English

Merges develop into main after PR #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)