### PR TITLE
chore: enforce self-review as a PR gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,7 @@
+## Pull Request Rules
+
+Every PR must pass the review loop (`review-loop.sh --dry-run`) before merging. No exceptions. We eat our own dog food — if Mr. Overkill can't approve it, neither can you.
+
 ## Branch Rules
 
 Always commit and push before ending work on any branch other than develop.


### PR DESCRIPTION
## Summary
- PR rule: must pass review-loop before merging
- Merges develop into main after PR #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)