### PR TITLE
docs: add self-review gate to Contributing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ This removes the `.review-loop/` directory and its `.gitignore` entry.
 2. Create a feature branch (`git checkout -b feat/my-feature`)
 3. Commit your changes
 4. Open a Pull Request against `develop`
-5. Run `review-loop.sh -n 3 --dry-run` on your PR branch — **required**. Let Mr. Overkill review and fix your code before a human ever sees it. Even one line of documentation or a comment deserves a review. We eat our own dog food.
+5. Run `review-loop.sh -n 3 --dry-run` on your PR branch — **required**. Let Mr. Overkill review your code before a human ever sees it. Even one line of documentation or a comment deserves a review. We eat our own dog food.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Contributing 섹션에 `review-loop.sh --dry-run` 통과 필수 단계 추가
- "We eat our own dog food."

🤖 Generated with [Claude Code](https://claude.com/claude-code)