### PR TITLE
feat: increase default self-review sub-loop from 2 to 4

### DIFF
--- a/.reviewlooprc.example
+++ b/.reviewlooprc.example
@@ -8,8 +8,8 @@
 # Maximum review-fix iterations (default: unset, required via CLI)
 # MAX_LOOP=5
 
-# Maximum self-review sub-iterations per fix (default: 2, set 0 to disable)
-# MAX_SUBLOOP=2
+# Maximum self-review sub-iterations per fix (default: 4, set 0 to disable)
+# MAX_SUBLOOP=4
 
 # Run review only, do not fix (default: false)
 # DRY_RUN=false

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ review-loop.sh [OPTIONS]
 Options:
   -t, --target <branch>    Target branch to diff against (default: develop)
   -n, --max-loop <N>       Maximum review-fix iterations (required)
-  --max-subloop <N>        Maximum self-review sub-iterations per fix (default: 2)
+  --max-subloop <N>        Maximum self-review sub-iterations per fix (default: 4)
   --no-self-review         Disable self-review (equivalent to --max-subloop 0)
   --dry-run                Run review only, do not fix
   --no-auto-commit         Fix but do not commit/push (single iteration)
@@ -99,7 +99,7 @@ Create a `.reviewlooprc` file in your project root to set defaults. CLI argument
 # .reviewlooprc
 TARGET_BRANCH="main"
 MAX_LOOP=5
-MAX_SUBLOOP=2
+MAX_SUBLOOP=4
 AUTO_COMMIT=true
 PROMPTS_DIR="./custom-prompts"
 ```

--- a/bin/review-loop.sh
+++ b/bin/review-loop.sh
@@ -9,7 +9,7 @@ PROMPTS_DIR="$SCRIPT_DIR/../prompts/active"
 # ── Defaults ──────────────────────────────────────────────────────────
 TARGET_BRANCH="develop"
 MAX_LOOP=""
-MAX_SUBLOOP=2
+MAX_SUBLOOP=4
 DRY_RUN=false
 AUTO_COMMIT=true
 
@@ -58,7 +58,7 @@ Usage: review-loop.sh [OPTIONS]
 Options:
   -t, --target <branch>    Target branch to diff against (default: develop)
   -n, --max-loop <N>       Maximum review-fix iterations (required)
-  --max-subloop <N>        Maximum self-review sub-iterations per fix (default: 2)
+  --max-subloop <N>        Maximum self-review sub-iterations per fix (default: 4)
   --no-self-review         Disable self-review (equivalent to --max-subloop 0)
   --dry-run                Run review only, do not fix
   --no-dry-run             Force fixes even if .reviewlooprc sets DRY_RUN=true


### PR DESCRIPTION
## Summary
- Self-review sub-loop의 기본 반복 횟수를 2에서 4로 상향
- 2회로는 Claude가 자체 수정을 수렴시키기에 부족한 경우가 많아, 여유를 더 줌
- `bin/review-loop.sh`, `README.md`, `.reviewlooprc.example` 세 파일의 default 값 및 문서 일괄 변경

## Test plan
- [ ] `bin/review-loop.sh --help` 에서 `(default: 4)` 확인
- [ ] `grep MAX_SUBLOOP bin/review-loop.sh README.md .reviewlooprc.example` 로 누락 없이 변경 확인
- [ ] `review-loop.sh --dry-run` 실행 시 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)