### PR TITLE
feat: add Codex CLI token limit checker

### DIFF
--- a/bin/lib/check-codex-limit.sh
+++ b/bin/lib/check-codex-limit.sh
@@ -31,8 +31,8 @@ _codex_limit_find_latest_token_count() {
     _dir="$_sessions_dir/$_day_dir"
     [[ -d "$_dir" ]] || continue
 
-    # List .jsonl files in reverse alphabetical order (newest first)
-    _files=$(ls -1r "$_dir"/*.jsonl 2>/dev/null) || continue
+    # List .jsonl files by modification time (newest first)
+    _files=$(ls -1t "$_dir"/*.jsonl 2>/dev/null) || continue
     [[ -n "$_files" ]] || continue
 
     while IFS= read -r _f; do


### PR DESCRIPTION
## Summary

- Add `bin/lib/check-codex-limit.sh` — reads `used_percent` directly from Codex session logs (`~/.codex/sessions/`)
- No OAuth, tier detection, or local token estimation needed (unlike the Claude version) — Codex logs are already authoritative
- Follows existing `check-claude-limit.sh` patterns: guard clause, library/standalone dual mode, `_budget_sufficient()` API

## Details

- Scans session logs from today back 7 days (newest first, short-circuits on first hit)
- Handles staleness: expired `resets_at` windows reported as 0% / null
- Guards against non-numeric `resets_at` values to prevent bash arithmetic errors
- macOS/GNU date compatible

Closes #31

## Test plan

- [x] `bash -n` syntax check
- [x] Standalone execution shows correct output
- [x] Library mode: `_check_codex_token_budget` returns valid JSON, `_codex_budget_sufficient` works for all scopes
- [x] No-session environment (`HOME=/tmp/nonexistent`): returns `five_hour_used_pct: 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)