### PR TITLE
fix(lib): use return/exit conditionally in load guards

### DIFF
--- a/bin/lib/check-claude-limit.sh
+++ b/bin/lib/check-claude-limit.sh
@@ -8,7 +8,9 @@
 #   _check_claude_token_budget   # → JSON to stdout
 #   _claude_budget_sufficient full && echo "GO" || echo "NO-GO"
 
-[[ -n "${_CHECK_CLAUDE_LIMIT_SH_LOADED:-}" ]] && return 0
+if [[ -n "${_CHECK_CLAUDE_LIMIT_SH_LOADED:-}" ]]; then
+  [[ "${BASH_SOURCE[0]}" != "${0}" ]] && return 0 || exit 0
+fi
 _CHECK_CLAUDE_LIMIT_SH_LOADED=1
 
 # ── Internal: Detect subscription tier ───────────────────────────────

--- a/bin/lib/check-codex-limit.sh
+++ b/bin/lib/check-codex-limit.sh
@@ -8,7 +8,9 @@
 #   _check_codex_token_budget   # → JSON to stdout
 #   _codex_budget_sufficient full && echo "GO" || echo "NO-GO"
 
-[[ -n "${_CHECK_CODEX_LIMIT_SH_LOADED:-}" ]] && return 0
+if [[ -n "${_CHECK_CODEX_LIMIT_SH_LOADED:-}" ]]; then
+  [[ "${BASH_SOURCE[0]}" != "${0}" ]] && return 0 || exit 0
+fi
 _CHECK_CODEX_LIMIT_SH_LOADED=1
 
 # ── Internal: Find latest token_count event ──────────────────────────


### PR DESCRIPTION
## Summary

- Fix load guard `return 0` error when script is executed standalone with the guard variable already set in the environment
- Applied to both `check-codex-limit.sh` and `check-claude-limit.sh`

## Details

`_CHECK_*_LIMIT_SH_LOADED=1 bash bin/lib/check-*-limit.sh` previously printed:
```
return: can only 'return' from a function or sourced script
```

Now checks `BASH_SOURCE[0]` to use `return` when sourced, `exit` when executed directly.

## Test plan

- [x] `bash -n` syntax check (both files)
- [x] `_CHECK_CODEX_LIMIT_SH_LOADED=1 bash check-codex-limit.sh` — silent exit 0
- [x] `_CHECK_CLAUDE_LIMIT_SH_LOADED=1 bash check-claude-limit.sh` — silent exit 0
- [x] Normal standalone execution — works as before
- [x] Double `source` — idempotency guard still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)