### PR TITLE
fix: default review-loop budget scope to micro

### DIFF
--- a/src/mr_overkill/cli.py
+++ b/src/mr_overkill/cli.py
@@ -350,7 +350,7 @@ def parse_review_loop_args(
         parser.error("RETRY_MAX_WAIT must be a positive integer")
     if retry_initial_wait < 1:
         parser.error("RETRY_INITIAL_WAIT must be a positive integer")
-    budget_scope_str = rc.get("BUDGET_SCOPE", "module")
+    budget_scope_str = rc.get("BUDGET_SCOPE", "micro")
 
     prompts_dir = _resolve_prompts_dir(
         rc.get("PROMPTS_DIR", ".overkill/prompts/active")

--- a/src/mr_overkill/models.py
+++ b/src/mr_overkill/models.py
@@ -165,7 +165,7 @@ class LoopConfig:
     # Retry / budget
     retry_max_wait: int = 7200
     retry_initial_wait: int = 30
-    budget_scope: BudgetScope = BudgetScope.MODULE
+    budget_scope: BudgetScope = BudgetScope.MICRO
     diagnostic_log: bool = False
 
     # Paths


### PR DESCRIPTION
## Summary
- review-loop budget scope default changed from `module` (75%) to `micro` (90%)
- `LoopConfig` default also updated to `MICRO`
- refactor-suggest keeps `module` (75%) — only it needs the tighter budget gate

## Test plan
- [ ] Run `overkill review-loop --dry-run` and confirm budget check uses micro threshold
- [ ] Run `overkill refactor-suggest` and confirm it still uses module threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)