### PR TITLE
fix: allow preventive actions for skipped findings

### DIFF
--- a/prompts/active/claude-fix-execute.prompt.md
+++ b/prompts/active/claude-fix-execute.prompt.md
@@ -1,7 +1,7 @@
 좋아, 네 판단대로 고쳐줘.
 
 - 네가 동의한 finding만 고쳐
-- SKIP하겠다고 한 건 고치지 마
+- SKIP하겠다고 한 finding 자체는 고치지 마. 단, opinion에서 같은 false positive 재발을 방지하는 작은 조치를 제안했으면 (주석 추가, @deprecated 표시, dead code 제거 등) 그건 해줘.
 - 최소한의 변경만 해. 기존 코드 스타일을 따라
 - 끝나면 아래 형식으로 요약해줘:
 
@@ -10,4 +10,5 @@
 
 - [FIXED] <finding title>: <변경 내용>
 - [SKIPPED] <finding title>: <SKIP 사유>
+- [SKIPPED] <finding title>: <SKIP 사유> → 예방 조치: <조치 내용>
 ```

--- a/prompts/active/claude-refactor-fix-execute.prompt.md
+++ b/prompts/active/claude-refactor-fix-execute.prompt.md
@@ -1,7 +1,7 @@
 좋아, 네 판단대로 리팩토링해줘.
 
 - 네가 동의한 finding만 고쳐
-- SKIP하겠다고 한 건 고치지 마
+- SKIP하겠다고 한 finding 자체는 고치지 마. 단, opinion에서 같은 false positive 재발을 방지하는 작은 조치를 제안했으면 (주석 추가, @deprecated 표시, dead code 제거 등) 그건 해줘.
 - refactoring_plan의 steps 순서대로 진행해
 - 각 step이 끝날 때마다 코드가 정상 동작하는 상태를 유지해
 - 최소한의 변경만 해. 기존 코드 스타일을 따라
@@ -12,6 +12,7 @@
 
 - [FIXED] <finding title>: <변경 내용>
 - [SKIPPED] <finding title>: <SKIP 사유>
+- [SKIPPED] <finding title>: <SKIP 사유> → 예방 조치: <조치 내용>
 ```
 
 ## Safety Guards


### PR DESCRIPTION
## Summary

- SKIP된 finding에 대해 opinion에서 제안한 예방 조치(주석, @deprecated, dead code 제거)를 execute 단계에서 수행할 수 있도록 프롬프트 변경
- 기존: `SKIP하겠다고 한 건 고치지 마` → 모든 행동 차단
- 변경: finding 자체는 안 고치되, false positive 재발 방지를 위한 작은 조치는 허용
- Fix Summary 형식에 예방 조치 표기 추가

## Context

FeverCoach 백엔드 10-iteration 리뷰에서 iteration 6의 dead code false positive가 SKIP되었지만, opinion에서 제안한 `@deprecated` 표시까지 차단됨. 예방 조치가 허용되었다면 다음 리뷰에서 같은 false positive 재발을 방지할 수 있었음.

## Follow-up

- #133: 이전 iteration의 fix decisions를 `reviewer_context`로 다음 리뷰어에 전달

## Test plan

- [ ] `overkill review-loop --dry-run`으로 프롬프트 정상 렌더링 확인
- [ ] 실제 리뷰 루프에서 SKIP + 예방 조치가 Fix Summary에 올바르게 표기되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)