### PR TITLE
chore: deprecate legacy bash scripts, use Python CLI only

### DIFF
--- a/.review-loop/prompts/active/claude-refactor-full.prompt.md
+++ b/.review-loop/prompts/active/claude-refactor-full.prompt.md
@@ -1,1 +1,0 @@
-codex-refactor-full.prompt.md

--- a/.review-loop/prompts/active/claude-refactor-layer.prompt.md
+++ b/.review-loop/prompts/active/claude-refactor-layer.prompt.md
@@ -1,1 +1,0 @@
-codex-refactor-layer.prompt.md

--- a/.review-loop/prompts/active/claude-refactor-micro.prompt.md
+++ b/.review-loop/prompts/active/claude-refactor-micro.prompt.md
@@ -1,1 +1,0 @@
-codex-refactor-micro.prompt.md

--- a/.review-loop/prompts/active/claude-refactor-module.prompt.md
+++ b/.review-loop/prompts/active/claude-refactor-module.prompt.md
@@ -1,1 +1,0 @@
-codex-refactor-module.prompt.md

--- a/.review-loop/prompts/active/claude-review.prompt.md
+++ b/.review-loop/prompts/active/claude-review.prompt.md
@@ -1,1 +1,0 @@
-codex-review.prompt.md

--- a/uv.lock
+++ b/uv.lock
@@ -247,7 +247,7 @@ wheels = [
 
 [[package]]
 name = "overkill"
-version = "0.5.4"
+version = "0.5.5"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- Remove 5 tracked symlinks under `.review-loop/prompts/active/` — the only git-tracked files in the legacy directory
- Python CLI (`overkill`) already has 100% feature parity with `--reviewer-backend claude|codex|gemini` support
- Bash scripts (`.review-loop/bin/`) were already untracked and deleted locally

## Context

The project had two parallel implementations:
- **Bash** (`.review-loop/bin/`): `review-loop.sh`, `refactor-suggest.sh` + libs — legacy, unreferenced
- **Python** (`src/mr_overkill/`): unified `loop_engine.py` + backend-selectable agents — production

Nothing references the bash scripts (README, CI, pyproject.toml all use `overkill` CLI). The 5 symlinks were remnants from before the `.gitignore` rule was added.

## Test plan

- [x] `pytest tests/ -v` — 281 passed
- [ ] `overkill refactor-suggest --reviewer-backend claude --dry-run` — verify Claude reviewer works

🤖 Generated with [Claude Code](https://claude.com/claude-code)