### PR TITLE
release: v0.5.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 # Legacy directory (pre-migration)
 .review-loop/
 
+# Environment
+.env
+
 # Python
 __pycache__/
 *.py[cod]

--- a/.review-loop/prompts/active/claude-refactor-full.prompt.md
+++ b/.review-loop/prompts/active/claude-refactor-full.prompt.md
@@ -1,1 +1,0 @@
-codex-refactor-full.prompt.md

--- a/.review-loop/prompts/active/claude-refactor-layer.prompt.md
+++ b/.review-loop/prompts/active/claude-refactor-layer.prompt.md
@@ -1,1 +1,0 @@
-codex-refactor-layer.prompt.md

--- a/.review-loop/prompts/active/claude-refactor-micro.prompt.md
+++ b/.review-loop/prompts/active/claude-refactor-micro.prompt.md
@@ -1,1 +1,0 @@
-codex-refactor-micro.prompt.md

--- a/.review-loop/prompts/active/claude-refactor-module.prompt.md
+++ b/.review-loop/prompts/active/claude-refactor-module.prompt.md
@@ -1,1 +1,0 @@
-codex-refactor-module.prompt.md

--- a/.review-loop/prompts/active/claude-review.prompt.md
+++ b/.review-loop/prompts/active/claude-review.prompt.md
@@ -1,1 +1,0 @@
-codex-review.prompt.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "overkill"
-version = "0.5.5"
+version = "0.5.6"
 description = "AI-powered code review loop — automates Codex review + Claude fix cycles"
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -247,7 +247,7 @@ wheels = [
 
 [[package]]
 name = "overkill"
-version = "0.5.4"
+version = "0.5.5"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- Remove legacy `.review-loop/` tracked symlinks — Python CLI is the sole implementation
- Add `.env` to `.gitignore`
- Bump version to 0.5.6

## Changes included

- PR #137: `chore: deprecate legacy bash scripts, use Python CLI only`
- `.env` gitignore addition

## Test plan

- [x] `pytest tests/ -v` — 281 passed
- [x] `overkill review-loop --reviewer-backend gemini` — all_clear
- [ ] PyPI publish via `publish.yml` after merge + tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)