### PR TITLE
release: v0.6.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 # Legacy directory (pre-migration)
 .review-loop/
 
+# Environment
+.env
+
 # Python
 __pycache__/
 *.py[cod]

--- a/.review-loop/prompts/active/claude-refactor-full.prompt.md
+++ b/.review-loop/prompts/active/claude-refactor-full.prompt.md
@@ -1,1 +1,0 @@
-codex-refactor-full.prompt.md

--- a/.review-loop/prompts/active/claude-refactor-layer.prompt.md
+++ b/.review-loop/prompts/active/claude-refactor-layer.prompt.md
@@ -1,1 +1,0 @@
-codex-refactor-layer.prompt.md

--- a/.review-loop/prompts/active/claude-refactor-micro.prompt.md
+++ b/.review-loop/prompts/active/claude-refactor-micro.prompt.md
@@ -1,1 +1,0 @@
-codex-refactor-micro.prompt.md

--- a/.review-loop/prompts/active/claude-refactor-module.prompt.md
+++ b/.review-loop/prompts/active/claude-refactor-module.prompt.md
@@ -1,1 +1,0 @@
-codex-refactor-module.prompt.md

--- a/.review-loop/prompts/active/claude-review.prompt.md
+++ b/.review-loop/prompts/active/claude-review.prompt.md
@@ -1,1 +1,0 @@
-codex-review.prompt.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ git log HEAD..origin/<target-branch> --oneline
 2. **Release branch → main**
    - Create `release/x.y.z` from `develop`
    - Bump version in `pyproject.toml` (`[project] version`)
+   - Run `uv lock` to sync `uv.lock` with the new version
    - Commit: `chore: bump version to x.y.z`
    - Push and open PR targeting `main`
    - Run review loop — if the review produces fix commits, merge them into `develop` first (via PR) before merging the release PR into `main`

--- a/README.md
+++ b/README.md
@@ -50,10 +50,11 @@ git clone --depth 1 https://github.com/modocai/mr-overkill.git /tmp/overkill \
 
 You need these to participate in the madness:
 
-**Accounts** (yes, you need both — that's the point):
+**Accounts** (yes, you need all three — that's the point):
 
 - [OpenAI](https://platform.openai.com/) account (paid plan) — because free tier is for weak code
 - [Anthropic](https://console.anthropic.com/) account (Pro/Max plan or API credits) — because Claude needs to think *deeply* about your variable names
+- [Google AI](https://aistudio.google.com/) account (API key) — because Gemini wants in on the overkill too
 
 **Runtime**:
 
@@ -64,8 +65,9 @@ You need these to participate in the madness:
 **CLI Tools**:
 
 ```bash
-npm install -g @openai/codex        # Codex CLI
+npm install -g @openai/codex             # Codex CLI
 npm install -g @anthropic-ai/claude-code  # Claude Code CLI
+npm install -g @google/gemini-cli         # Gemini CLI
 ```
 
 - [jq](https://jqlang.github.io/jq/) — JSON processor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "overkill"
-version = "0.5.5"
+version = "0.6.0"
 description = "AI-powered code review loop — automates Codex review + Claude fix cycles"
 readme = "README.md"
 license = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "overkill"
 version = "0.6.0"
-description = "AI-powered code review loop — automates Codex review + Claude fix cycles"
+description = "AI-powered code review loop — automates Codex/Gemini review + Claude fix cycles"
 readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "overkill"
-version = "0.6.0"
+version = "0.6.1"
 description = "AI-powered code review loop — automates Codex/Gemini review + Claude fix cycles"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/mr_overkill/agents.py
+++ b/src/mr_overkill/agents.py
@@ -385,7 +385,7 @@ class GeminiReviewAgent(ReviewAgent):
         return retry_gemini_cmd(
             output_path,
             "Gemini review",
-            ["gemini", "--sandbox", "--approval-mode", "plan", "-p", "-"],
+            ["gemini", "--sandbox", "--approval-mode", "yolo", "-p", "-"],
             stdin=prompt_text,
             max_wait=config.retry_max_wait,
             initial_wait=config.retry_initial_wait,
@@ -441,7 +441,7 @@ class GeminiRefactorReviewAgent(ReviewAgent):
         return retry_gemini_cmd(
             output_path,
             "Gemini analysis",
-            ["gemini", "--sandbox", "--approval-mode", "plan", "-p", "-"],
+            ["gemini", "--sandbox", "--approval-mode", "yolo", "-p", "-"],
             stdin=prompt_text,
             max_wait=config.retry_max_wait,
             initial_wait=config.retry_initial_wait,

--- a/src/mr_overkill/budget_report.py
+++ b/src/mr_overkill/budget_report.py
@@ -58,10 +58,17 @@ def _print_codex(status: BudgetStatus) -> None:
     print()
 
 
+def _print_gemini() -> None:
+    print("Gemini Budget")
+    print(_HEADER)
+    print("  No local budget data (API-key billing).")
+    print()
+
+
 def _print_scope_table(claude_st: BudgetStatus, codex_st: BudgetStatus) -> None:
     print("Scope Thresholds")
     print(_HEADER)
-    print("           Claude  Codex")
+    print("           Claude  Codex   Gemini")
     scopes = (
         BudgetScope.MICRO, BudgetScope.MODULE,
         BudgetScope.LAYER, BudgetScope.FULL,
@@ -72,7 +79,7 @@ def _print_scope_table(claude_st: BudgetStatus, codex_st: BudgetStatus) -> None:
             x_label = "GO" if budget_sufficient(scope, codex_st) else "NOGO"
         else:
             c_label = x_label = "—"
-        print(f"  {scope.value:<8} {c_label:<7} {x_label}")
+        print(f"  {scope.value:<8} {c_label:<7} {x_label:<7} —")
 
 
 def print_budget_report(*, json_mode: bool = False) -> int:
@@ -88,11 +95,13 @@ def print_budget_report(*, json_mode: bool = False) -> int:
         payload = {
             "claude": asdict(claude_st),
             "codex": asdict(codex_st),
+            "gemini": {"mode": "api-key", "note": "no local budget data"},
         }
         print(json.dumps(payload, indent=2))
         return 0
 
     _print_claude(claude_st)
     _print_codex(codex_st)
+    _print_gemini()
     _print_scope_table(claude_st, codex_st)
     return 0

--- a/src/mr_overkill/budget_report.py
+++ b/src/mr_overkill/budget_report.py
@@ -11,7 +11,7 @@ from mr_overkill.budget.claude import check_token_budget as claude_check
 from mr_overkill.budget.codex import check_token_budget as codex_check
 from mr_overkill.models import BudgetScope, BudgetStatus
 
-_HEADER = "\u2550" * 24  # ════════════════════════
+_HEADER = "\u2550" * 33  # ═════════════════════════════════
 
 
 def _fmt_pct(pct: int | None) -> str:

--- a/uv.lock
+++ b/uv.lock
@@ -247,7 +247,7 @@ wheels = [
 
 [[package]]
 name = "overkill"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -247,7 +247,7 @@ wheels = [
 
 [[package]]
 name = "overkill"
-version = "0.5.5"
+version = "0.6.0"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -247,7 +247,7 @@ wheels = [
 
 [[package]]
 name = "overkill"
-version = "0.5.4"
+version = "0.5.5"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- Deprecate legacy bash scripts — Python CLI (`overkill`) is the sole implementation
- Add Gemini as reviewer backend (README, agents, budget report)
- Fix Gemini approval mode (`plan` → `yolo` in sandbox)
- Add `.env` to `.gitignore`

## Test plan

- [x] `pytest tests/ -v` — 281 passed
- [x] `overkill review-loop --reviewer-backend gemini` — all_clear (2 iterations of review fixes)
- [ ] PyPI publish via `publish.yml` after merge + tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)