### PR TITLE
chore: merge review fix (uv.lock sync) into develop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "overkill"
-version = "0.6.0"
+version = "0.6.1"
 description = "AI-powered code review loop — automates Codex/Gemini review + Claude fix cycles"
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -247,7 +247,7 @@ wheels = [
 
 [[package]]
 name = "overkill"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- Sync uv.lock with 0.6.1 version bump (review fix from release/0.6.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)