### PR TITLE
fix(retry): preserve structured_output in diagnostic stream-json mode

### DIFF
--- a/src/mr_overkill/retry.py
+++ b/src/mr_overkill/retry.py
@@ -26,9 +26,13 @@ BUDGET_POLL_MAX = 1200
 
 
 def extract_result_from_stream(stream_path: Path) -> str:
-    """Extract final result text from a Claude stream-json event log.
+    """Extract final result from a Claude stream-json event log.
 
-    Returns empty string if the file is empty or no result event found.
+    When the ``result`` event includes a ``structured_output`` object
+    (set by ``--json-schema``), the JSON-encoded structured object is
+    returned so downstream parsers receive schema-conforming JSON.
+    Otherwise the plain ``result`` text is returned. Returns empty
+    string if the file is empty or no result event is found.
     """
     if not stream_path.is_file() or stream_path.stat().st_size == 0:
         return ""
@@ -39,10 +43,13 @@ def extract_result_from_stream(stream_path: Path) -> str:
             continue
         try:
             data = json.loads(line)
-            if data.get("result"):
-                last_result = data["result"]
-        except (json.JSONDecodeError, KeyError):
+        except json.JSONDecodeError:
             continue
+        structured = data.get("structured_output")
+        if isinstance(structured, dict):
+            last_result = json.dumps(structured)
+        elif data.get("result"):
+            last_result = data["result"]
     return last_result
 
 

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -46,6 +46,17 @@ class TestExtractResultFromStream:
         f.write_text(f"not json with result\n{ok_line}")
         assert extract_result_from_stream(f) == "ok"
 
+    def test_prefers_structured_output(self, tmp_path: Path) -> None:
+        f = tmp_path / "stream.jsonl"
+        structured = {"findings": [], "overall_correctness": "patch is correct"}
+        line = json.dumps({
+            "type": "result",
+            "result": "plain text summary",
+            "structured_output": structured,
+        })
+        f.write_text(line)
+        assert json.loads(extract_result_from_stream(f)) == structured
+
 
 class TestWaitForBudget:
     def test_budget_ok_immediately(self) -> None:


### PR DESCRIPTION
## Summary

Fix discovered by the 0.7.0 release-gate review loop (PR #145, codex iter 1). The schema-enforcement change in #143 added ``--output-format json --json-schema`` to Claude reviewer argv. When ``--diagnostic-log`` is also enabled, ``retry_claude_cmd`` appends ``--output-format stream-json`` and re-extracts the final result via ``extract_result_from_stream``, which only inspected the plain ``result`` text. The structured review object — emitted as ``structured_output`` in the stream events — was silently dropped, so the parser later saw a free-text summary instead of schema-conforming JSON.

## Change

``extract_result_from_stream`` now prefers ``structured_output`` (re-encoded as JSON) and falls back to ``result`` text, so diagnostic mode matches the regular path. Adds a unit test covering both branches.

## Why this lives on its own PR

CLAUDE.md release process requires fixes produced by the release-gate review loop to merge into ``develop`` first, before the release PR (#145) merges into ``main``. This is that intermediate PR. After it's in develop, we'll merge the ``release/0.7.0`` PR into main.

## Test plan

- [x] ``uv run pytest tests/test_retry.py`` (20/20 passing)
- [x] Identical fix already passed iter 2 review on the release branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)