### PR TITLE
feat(review-loop): default --ci-trigger-mode to last-only

### DIFF
--- a/.overkillrc.example
+++ b/.overkillrc.example
@@ -17,13 +17,13 @@
 # Enable auto-commit of fixes (default: true)
 # AUTO_COMMIT=true
 
-# CI trigger policy for iteration commits (default: every)
-#   every     — each iteration commit triggers CI
+# CI trigger policy for iteration commits (default: last-only)
 #   last-only — append "[skip ci]" to each iteration commit; push a single
 #               empty "chore: trigger CI" commit only when the loop ends
 #               with all_clear (saves CI cost on long iteration runs)
+#   every     — each iteration commit triggers CI (pre-0.3 behaviour)
 #   none      — append "[skip ci]"; no trigger commit (forks / CI-less repos)
-# CI_TRIGGER_MODE="every"
+# CI_TRIGGER_MODE="last-only"
 
 # Path to active prompt templates (default: <script_dir>/../prompts/active)
 # PROMPTS_DIR="./custom-prompts"

--- a/README.md
+++ b/README.md
@@ -102,10 +102,11 @@ Options:
   --no-auto-commit         Fix but do not commit/push (single iteration)
   --resume                 Resume from a previously interrupted run (reuses existing logs)
   --reviewer-backend <be>  Reviewer backend: claude|codex (default: codex)
-  --ci-trigger-mode <m>    CI trigger policy: every|last-only|none (default: every).
+  --ci-trigger-mode <m>    CI trigger policy: every|last-only|none (default: last-only).
                            'last-only' tags each iteration commit with [skip ci]
                            and pushes a single empty trigger commit on PASS —
                            CI runs once instead of once per iteration.
+                           Use 'every' to restore pre-0.3 per-commit CI.
   --diagnostic-log         Save full Claude event stream to sidecar files
 
 Examples:

--- a/src/mr_overkill/cli.py
+++ b/src/mr_overkill/cli.py
@@ -312,9 +312,9 @@ def parse_review_loop_args(
         choices=["every", "last-only", "none"],
         help=(
             "CI trigger policy for iteration commits. "
-            "'every' (default): every commit triggers CI. "
-            "'last-only': append [skip ci] to iteration commits and push a "
-            "single empty 'chore: trigger CI' commit only on PASS. "
+            "'last-only' (default): append [skip ci] to iteration commits and "
+            "push a single empty 'chore: trigger CI' commit only on PASS. "
+            "'every': every commit triggers CI. "
             "'none': append [skip ci] with no trigger commit."
         ),
     )
@@ -439,7 +439,7 @@ def parse_review_loop_args(
     ci_trigger_mode = (
         args.ci_trigger_mode
         if args.ci_trigger_mode is not None
-        else rc.get("CI_TRIGGER_MODE", "every")
+        else rc.get("CI_TRIGGER_MODE", "last-only")
     )
     if ci_trigger_mode not in ("every", "last-only", "none"):
         parser.error(

--- a/src/mr_overkill/models.py
+++ b/src/mr_overkill/models.py
@@ -163,12 +163,12 @@ class LoopConfig:
     auto_approve: bool = False
 
     # CI trigger policy for iteration commits:
-    #   "every"     — current behaviour: each commit triggers CI.
-    #   "last-only" — append "[skip ci]" to iteration commits; push a single
-    #                 empty "chore: trigger CI" commit only on ALL_CLEAR.
+    #   "last-only" — default: append "[skip ci]" to iteration commits; push a
+    #                 single empty "chore: trigger CI" commit only on ALL_CLEAR.
+    #   "every"     — each commit triggers CI (pre-0.3 behaviour).
     #   "none"      — append "[skip ci]" to iteration commits; never emit a
     #                 trigger commit (forks / CI-less repos).
-    ci_trigger_mode: str = "every"
+    ci_trigger_mode: str = "last-only"
 
     # Retry / budget
     retry_max_wait: int = 7200

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -329,7 +329,7 @@ class TestParseReviewLoopArgs:
     ) -> None:
         mock_run.return_value = MagicMock(returncode=0, stdout="/tmp/repo")
         config = parse_review_loop_args(["-n", "1"])
-        assert config.ci_trigger_mode == "every"
+        assert config.ci_trigger_mode == "last-only"
 
     @patch("mr_overkill.cli._detect_pr_number", return_value=None)
     @patch("mr_overkill.cli._detect_current_branch", return_value="feat/x")


### PR DESCRIPTION
## Summary
- Flip `LoopConfig.ci_trigger_mode` default from `every` to `last-only` so a vanilla `overkill review-loop` no longer fires CI on every iteration commit.
- Update the `--ci-trigger-mode` help, `.overkillrc.example`, and README to document the new default. Existing users can restore previous behaviour with `--ci-trigger-mode every` (or `CI_TRIGGER_MODE=every` in `.overkillrc`).
- Update `test_ci_trigger_mode_default` to assert the new default. All other `ci_trigger_mode` tests already pass explicit values.

## Why
Most review-loop runs take several iterations before reaching PASS, and intermediate commits trigger CI workflows that nobody acts on — wasting Actions minutes and queue time. `last-only` keeps reviewer-visible commits but emits a single trigger commit on `ALL_CLEAR`, which matches what almost every user actually wants.

## Test plan
- [x] `uv run pytest` — 307 passed
- [x] `uv run ruff check src tests` — clean
- [x] `uv run mypy src` — clean
- [ ] `overkill review-loop --dry-run -n 3` on this branch must pass per CLAUDE.md PR rules