### PR TITLE
fix(budget): stop gating Codex runs on stale plan rate limits

### DIFF
--- a/.overkillrc.example
+++ b/.overkillrc.example
@@ -38,6 +38,12 @@
 # Pre-flight budget check scope: micro (<90%) or module (<75%) (default: module)
 # BUDGET_SCOPE="module"
 
+# ── Budget Gate ─────────────────────────────────────────────────────
+# Skip token-budget checks entirely. Use when local budget data is stale or
+# wrong (e.g. Codex session logs left over from a previous login).
+# Equivalent to --no-budget-gate / OVERKILL_SKIP_BUDGET=1. (default: false)
+# NO_BUDGET_GATE=false
+
 # ── Diagnostic Logging ──────────────────────────────────────────────
 # Save full Claude event stream (tool calls, reasoning) to .stream.jsonl files.
 # Useful for debugging missed findings. (default: false)

--- a/.refactorsuggestrc.example
+++ b/.refactorsuggestrc.example
@@ -44,6 +44,12 @@
 # Pre-flight budget check scope: micro (<90%) or module (<75%) (default: module)
 # BUDGET_SCOPE="module"
 
+# ── Budget Gate ─────────────────────────────────────────────────────
+# Skip token-budget checks entirely. Use when local budget data is stale or
+# wrong (e.g. Codex session logs left over from a previous login).
+# Equivalent to --no-budget-gate / OVERKILL_SKIP_BUDGET=1. (default: false)
+# NO_BUDGET_GATE=false
+
 # ── Diagnostic Logging ──────────────────────────────────────────────
 # Save full Claude event stream (tool calls, reasoning) to .stream.jsonl files.
 # Useful for debugging missed findings. (default: false)

--- a/README.md
+++ b/README.md
@@ -292,9 +292,11 @@ All logs are git-ignored by default (inside `.overkill/`).
 The budget checker verifies Claude Code's 5-hour rate limit **before** starting expensive loops.
 
 Codex is checked too, but only when it authenticates through a ChatGPT plan.
-Auth mode is read from `$CODEX_HOME/auth.json` (default `~/.codex/auth.json`);
-under API-key auth there are no plan rate-limit windows, so the gate is skipped
-entirely and stale session logs from a previous plan login are ignored.
+Auth mode is read from `$CODEX_HOME/auth.json` (default `~/.codex/auth.json`),
+falling back to the login method in `config.toml` when Codex keeps credentials
+in the OS keyring instead; under API-key auth there are no plan rate-limit
+windows, so the gate is skipped entirely and stale session logs from a previous
+plan login are ignored.
 
 ### How it estimates usage
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Options:
                            CI runs once instead of once per iteration.
                            Use 'every' to restore pre-0.3 per-commit CI.
   --diagnostic-log         Save full Claude event stream to sidecar files
+  --no-budget-gate         Skip token-budget checks and run regardless
+                           (same as OVERKILL_SKIP_BUDGET=1)
 
 Examples:
   overkill review-loop -t main -n 3          # diff against main, max 3 loops
@@ -141,6 +143,8 @@ Options:
   --with-review-loops <N>  Set review-loop iteration count (implies --with-review)
   --reviewer-backend <be>  Reviewer backend: claude|codex (default: codex)
   --diagnostic-log         Save full Claude event stream to sidecar files
+  --no-budget-gate         Skip token-budget checks and run regardless
+                           (same as OVERKILL_SKIP_BUDGET=1)
 
 Examples:
   overkill refactor-suggest -n 3                             # auto scope (budget-aware)
@@ -287,6 +291,11 @@ All logs are git-ignored by default (inside `.overkill/`).
 
 The budget checker verifies Claude Code's 5-hour rate limit **before** starting expensive loops.
 
+Codex is checked too, but only when it authenticates through a ChatGPT plan.
+Auth mode is read from `$CODEX_HOME/auth.json` (default `~/.codex/auth.json`);
+under API-key auth there are no plan rate-limit windows, so the gate is skipped
+entirely and stale session logs from a previous plan login are ignored.
+
 ### How it estimates usage
 
 | Mode | Data source | Accuracy |
@@ -306,6 +315,18 @@ Go/no-go decision based on current usage percentage:
 | `module` | 75% | Multi-file refactoring |
 | `layer` | TBD | Cross-cutting changes |
 | `full` | TBD | Full architecture review |
+
+### Bypassing the gate
+
+Budget data is an estimate read from local CLI logs, so it can be wrong — stale
+logs, a changed auth mode, or a new rate-limit payload shape. To run anyway:
+
+```bash
+overkill review-loop -n 3 --no-budget-gate   # per run
+OVERKILL_SKIP_BUDGET=1 overkill review-loop -n 3   # env var, covers every gate
+```
+
+`NO_BUDGET_GATE=true` in `.overkillrc` / `.refactorsuggestrc` makes it the default.
 
 ## Customizing Prompts
 

--- a/src/mr_overkill/__main__.py
+++ b/src/mr_overkill/__main__.py
@@ -85,11 +85,14 @@ def main() -> None:
             from mr_overkill.cli import parse_review_loop_args
             from mr_overkill.review_loop import run as review_run
 
-            review_config = parse_review_loop_args([
+            review_argv = [
                 "-t", config.target_branch,
                 "-n", str(extra.review_loops),
                 "--reviewer-backend", config.reviewer_backend,
-            ])
+            ]
+            if config.skip_budget_gate:
+                review_argv.append("--no-budget-gate")
+            review_config = parse_review_loop_args(review_argv)
             exit_code = review_run(review_config)
         sys.exit(exit_code)
     elif command == "check-budget":

--- a/src/mr_overkill/agents.py
+++ b/src/mr_overkill/agents.py
@@ -16,6 +16,7 @@ from abc import ABC, abstractmethod
 from importlib.resources import as_file, files
 from pathlib import Path
 
+from mr_overkill.budget import SKIP_BUDGET_ENV_VAR, budget_gate_disabled
 from mr_overkill.budget.claude import claude_budget_sufficient
 from mr_overkill.budget.codex import codex_budget_sufficient
 from mr_overkill.budget.gemini import gemini_budget_sufficient
@@ -88,6 +89,13 @@ def _budget_check(
     tool: str, scope: BudgetScope, max_wait: int
 ) -> bool:
     """Direct budget check without waiting."""
+    if budget_gate_disabled():
+        logger.info(
+            "Budget gate disabled via %s — skipping %s check.",
+            SKIP_BUDGET_ENV_VAR,
+            tool,
+        )
+        return True
     if tool == "claude":
         return claude_budget_sufficient(scope)
     if tool == "codex":
@@ -109,6 +117,12 @@ class _BudgetFn:
     def __call__(
         self, tool: str, scope: BudgetScope, max_wait: int
     ) -> bool:
+        if self._config.skip_budget_gate:
+            logger.info(
+                "Budget gate disabled (--no-budget-gate) — running %s anyway.",
+                tool,
+            )
+            return True
         actual = (
             max_wait if max_wait > 0 else self._config.retry_max_wait
         )

--- a/src/mr_overkill/budget/__init__.py
+++ b/src/mr_overkill/budget/__init__.py
@@ -7,6 +7,7 @@ Ports ``_budget_sufficient`` from ``common.sh`` and
 from __future__ import annotations
 
 import logging
+import os
 
 from mr_overkill.models import BudgetScope, BudgetStatus
 from mr_overkill.time_utils import codex_ts_to_iso
@@ -20,6 +21,28 @@ _THRESHOLDS: dict[BudgetScope, int | None] = {
     BudgetScope.LAYER: None,  # no threshold established
     BudgetScope.FULL: None,
 }
+
+# Rate-limit window kinds, keyed by the field they map onto in BudgetStatus.
+FIVE_HOUR_WINDOW = "five_hour"
+SEVEN_DAY_WINDOW = "seven_day"
+
+# Any window declared as one day or shorter counts as the short ("5-hour")
+# window; anything longer is the rolling weekly window.
+_SHORT_WINDOW_MAX_MINUTES = 24 * 60
+
+# Env escape hatch: set to 1/true/yes/on to bypass every budget gate.
+SKIP_BUDGET_ENV_VAR = "OVERKILL_SKIP_BUDGET"
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def budget_gate_disabled() -> bool:
+    """Return True if the user has disabled budget gating via the environment.
+
+    Local budget data is an estimate derived from CLI logs; when it is wrong
+    (stale logs, changed auth mode, new rate-limit shapes) the loop would
+    otherwise block with no way out.
+    """
+    return os.environ.get(SKIP_BUDGET_ENV_VAR, "").strip().lower() in _TRUTHY
 
 
 def has_threshold(scope: BudgetScope) -> bool:
@@ -71,6 +94,36 @@ def budget_sufficient(scope: BudgetScope, status: BudgetStatus) -> bool:
         threshold,
     )
     return False
+
+
+def codex_window_kind(window: dict[str, object] | None) -> str | None:
+    """Classify a Codex ``rate_limits`` window by its declared length.
+
+    Codex does not guarantee that ``primary`` is the short window — on some
+    plans ``primary`` carries the weekly (``window_minutes: 10080``) limit.
+    Returns ``None`` when the window omits ``window_minutes``, leaving the
+    caller to fall back to positional assignment.
+    """
+    if not window:
+        return None
+
+    raw = window.get("window_minutes")
+    if raw is None:
+        return None
+
+    try:
+        minutes = float(str(raw))
+    except ValueError:
+        return None
+
+    if minutes <= 0:
+        return None
+
+    return (
+        FIVE_HOUR_WINDOW
+        if minutes <= _SHORT_WINDOW_MAX_MINUTES
+        else SEVEN_DAY_WINDOW
+    )
 
 
 def codex_parse_window(

--- a/src/mr_overkill/budget/codex.py
+++ b/src/mr_overkill/budget/codex.py
@@ -94,6 +94,10 @@ def _login_status_auth_mode(home: Path) -> str | None:
     touches disk, so neither auth.json nor config.toml has to mention it.
     ``None`` means the probe told us nothing — Codex is missing from PATH, it
     failed, or it named a login we deliberately do not treat as API-key auth.
+
+    A keyring-backed login is exactly the setup that can make Codex block on an
+    OS keychain prompt, and this runs on the pre-flight path re-entered by every
+    budget poll, so the probe is bounded rather than allowed to stall the loop.
     """
     try:
         result = subprocess.run(
@@ -101,9 +105,10 @@ def _login_status_auth_mode(home: Path) -> str | None:
             capture_output=True,
             text=True,
             check=False,
+            timeout=5,
             env={**os.environ, "CODEX_HOME": str(home)},
         )
-    except OSError:
+    except (OSError, subprocess.TimeoutExpired):
         return None
 
     if result.returncode != 0:

--- a/src/mr_overkill/budget/codex.py
+++ b/src/mr_overkill/budget/codex.py
@@ -38,12 +38,19 @@ def codex_home() -> Path:
 def detect_auth_mode(home: Path | None = None) -> str:
     """Detect how the Codex CLI authenticates.
 
-    ``auth.json`` is authoritative: it records the mode chosen by the last
-    ``codex login``.  Falls back to ``OPENAI_API_KEY`` in the environment,
-    then to ``unknown`` (which keeps the plan-based budget gate active).
+    ``CODEX_API_KEY`` wins outright: Codex sends it even when ``auth.json``
+    holds a ChatGPT login.  Otherwise ``auth.json`` is authoritative, since it
+    records the mode chosen by the last ``codex login``.  Falls back to
+    ``OPENAI_API_KEY`` in the environment, then to ``unknown`` (which keeps the
+    plan-based budget gate active).
     """
     if home is None:
         home = codex_home()
+
+    # Checked before auth.json — and unlike OPENAI_API_KEY below, which loses
+    # to a cached ChatGPT login and so must stay a last resort.
+    if os.environ.get("CODEX_API_KEY", "").strip():
+        return AUTH_MODE_APIKEY
 
     try:
         auth = json.loads((home / "auth.json").read_text(encoding="utf-8"))

--- a/src/mr_overkill/budget/codex.py
+++ b/src/mr_overkill/budget/codex.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import tomllib
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -28,6 +29,14 @@ AUTH_MODE_APIKEY = "apikey"
 AUTH_MODE_CHATGPT = "chatgpt"
 AUTH_MODE_UNKNOWN = "unknown"
 
+# ``config.toml`` keys that record the login method Codex was set up with.
+# ``forced_login_method`` is the current name; ``preferred_auth_method`` is the
+# older one and still sits in configs written by earlier versions.
+_CONFIG_AUTH_KEYS = ("forced_login_method", "preferred_auth_method")
+
+# Spellings of API-key auth seen across auth.json and config.toml.
+_APIKEY_ALIASES = frozenset({"apikey", "api_key", "api-key"})
+
 
 def codex_home() -> Path:
     """Return the Codex config directory (``$CODEX_HOME`` or ``~/.codex``)."""
@@ -35,14 +44,35 @@ def codex_home() -> Path:
     return Path(raw) if raw else Path.home() / ".codex"
 
 
+def _config_auth_mode(home: Path) -> str | None:
+    """Return the login method declared in ``config.toml``, or ``None``.
+
+    Only API-key auth is reported: every other value leaves the plan-based
+    budget gate active, which is what the caller already defaults to.
+    """
+    try:
+        with (home / "config.toml").open("rb") as handle:
+            config = tomllib.load(handle)
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+
+    for key in _CONFIG_AUTH_KEYS:
+        value = config.get(key)
+        if isinstance(value, str) and value.strip().lower() in _APIKEY_ALIASES:
+            return AUTH_MODE_APIKEY
+
+    return None
+
+
 def detect_auth_mode(home: Path | None = None) -> str:
     """Detect how the Codex CLI authenticates.
 
     ``CODEX_API_KEY`` wins outright: Codex sends it even when ``auth.json``
     holds a ChatGPT login.  Otherwise ``auth.json`` is authoritative, since it
-    records the mode chosen by the last ``codex login``.  Falls back to
-    ``OPENAI_API_KEY`` in the environment, then to ``unknown`` (which keeps the
-    plan-based budget gate active).
+    records the mode chosen by the last ``codex login``.  Falls back to the
+    login method declared in ``config.toml``, then to ``OPENAI_API_KEY`` in the
+    environment, then to ``unknown`` (which keeps the plan-based budget gate
+    active).
     """
     if home is None:
         home = codex_home()
@@ -66,6 +96,12 @@ def detect_auth_mode(home: Path | None = None) -> str:
             return AUTH_MODE_CHATGPT
         if auth.get("OPENAI_API_KEY"):
             return AUTH_MODE_APIKEY
+
+    # auth.json can be missing entirely when Codex keeps credentials in the OS
+    # keyring (``cli_auth_credentials_store``); config.toml still records the
+    # login method, so consult it before giving up on the file layout.
+    if _config_auth_mode(home) == AUTH_MODE_APIKEY:
+        return AUTH_MODE_APIKEY
 
     if os.environ.get("OPENAI_API_KEY", "").strip():
         return AUTH_MODE_APIKEY

--- a/src/mr_overkill/budget/codex.py
+++ b/src/mr_overkill/budget/codex.py
@@ -31,9 +31,10 @@ AUTH_MODE_CHATGPT = "chatgpt"
 AUTH_MODE_UNKNOWN = "unknown"
 
 # ``config.toml`` keys that record the login method Codex was set up with.
-# ``forced_login_method`` is the current name; ``preferred_auth_method`` is the
-# older one and still sits in configs written by earlier versions.
-_CONFIG_AUTH_KEYS = ("forced_login_method", "preferred_auth_method")
+# Only ``forced_login_method`` is read: the older ``preferred_auth_method`` is
+# gone from current Codex, which silently ignores it, so a stale copy left in a
+# config would misreport the login Codex actually uses.
+_CONFIG_AUTH_KEYS = ("forced_login_method",)
 
 # Login-method spellings seen across auth.json and config.toml, mapped to the
 # canonical mode the budget gate compares against.  ``api`` is the only value
@@ -128,14 +129,14 @@ def detect_auth_mode(home: Path | None = None) -> str:
     holds a ChatGPT login.  Otherwise ``auth.json`` is authoritative, since it
     records the mode chosen by the last ``codex login``.  Falls back to the
     login method declared in ``config.toml``, then to what ``codex login
-    status`` reports, then to ``OPENAI_API_KEY`` in the environment, then to
-    ``unknown`` (which keeps the plan-based budget gate active).
+    status`` reports, then to ``unknown`` (which keeps the plan-based budget
+    gate active).
     """
     if home is None:
         home = codex_home()
 
-    # Checked before auth.json — and unlike OPENAI_API_KEY below, which loses
-    # to a cached ChatGPT login and so must stay a last resort.
+    # Checked before auth.json: Codex authenticates with this key regardless of
+    # what the last login stored.
     if os.environ.get("CODEX_API_KEY", "").strip():
         return AUTH_MODE_APIKEY
 
@@ -160,21 +161,17 @@ def detect_auth_mode(home: Path | None = None) -> str:
     # auth.json can be missing entirely when Codex keeps credentials in the OS
     # keyring (``cli_auth_credentials_store``); config.toml may still declare
     # the login method, so consult it before giving up on the file layout.
-    # ``forced_login_method`` constrains which login Codex will use, so it
-    # outranks an ambient OPENAI_API_KEY left there for other tools.
     config_mode = _config_auth_mode(home)
     if config_mode is not None:
         return config_mode
 
     # Nothing on disk names the login, which is normal for a keyring-backed
-    # one.  Ask Codex itself before falling back to guessing from the
-    # environment.
+    # one.  Ask Codex itself as a last resort.  An ambient OPENAI_API_KEY is
+    # deliberately not consulted: Codex does not authenticate with it, so a key
+    # left in the environment for other tools must not switch the gate off.
     status_mode = _login_status_auth_mode(home)
     if status_mode is not None:
         return status_mode
-
-    if os.environ.get("OPENAI_API_KEY", "").strip():
-        return AUTH_MODE_APIKEY
 
     return AUTH_MODE_UNKNOWN
 

--- a/src/mr_overkill/budget/codex.py
+++ b/src/mr_overkill/budget/codex.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import subprocess
 import tomllib
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -35,13 +36,25 @@ AUTH_MODE_UNKNOWN = "unknown"
 _CONFIG_AUTH_KEYS = ("forced_login_method", "preferred_auth_method")
 
 # Login-method spellings seen across auth.json and config.toml, mapped to the
-# canonical mode the budget gate compares against.
+# canonical mode the budget gate compares against.  ``api`` is the only value
+# current Codex accepts for ``forced_login_method`` — it rejects the ``apikey``
+# spellings outright — while auth.json writes ``apikey``.
 _AUTH_MODE_ALIASES = {
+    "api": AUTH_MODE_APIKEY,
     "apikey": AUTH_MODE_APIKEY,
     "api_key": AUTH_MODE_APIKEY,
     "api-key": AUTH_MODE_APIKEY,
     "chatgpt": AUTH_MODE_CHATGPT,
 }
+
+# Prefixes of ``codex login status`` output, mapped to the canonical mode.
+# Anything else (access tokens, "Not logged in") stays ``unknown`` so the
+# plan-based gate keeps running.
+_LOGIN_STATUS_MODES = (
+    ("logged in using an api key", AUTH_MODE_APIKEY),
+    ("logged in using amazon bedrock api key", AUTH_MODE_APIKEY),
+    ("logged in using chatgpt", AUTH_MODE_CHATGPT),
+)
 
 
 def codex_home() -> Path:
@@ -73,15 +86,48 @@ def _config_auth_mode(home: Path) -> str | None:
     return None
 
 
+def _login_status_auth_mode(home: Path) -> str | None:
+    """Return the mode reported by ``codex login status``, or ``None``.
+
+    This is the only way to read a keyring-backed login: the credential never
+    touches disk, so neither auth.json nor config.toml has to mention it.
+    ``None`` means the probe told us nothing — Codex is missing from PATH, it
+    failed, or it named a login we deliberately do not treat as API-key auth.
+    """
+    try:
+        result = subprocess.run(
+            ["codex", "login", "status"],
+            capture_output=True,
+            text=True,
+            check=False,
+            env={**os.environ, "CODEX_HOME": str(home)},
+        )
+    except OSError:
+        return None
+
+    if result.returncode != 0:
+        return None
+
+    # Codex prints the status line on stderr; stdout is checked too so a later
+    # version moving it there keeps working.
+    for stream in (result.stderr, result.stdout):
+        status = stream.strip().lower()
+        for prefix, mode in _LOGIN_STATUS_MODES:
+            if status.startswith(prefix):
+                return mode
+
+    return None
+
+
 def detect_auth_mode(home: Path | None = None) -> str:
     """Detect how the Codex CLI authenticates.
 
     ``CODEX_API_KEY`` wins outright: Codex sends it even when ``auth.json``
     holds a ChatGPT login.  Otherwise ``auth.json`` is authoritative, since it
     records the mode chosen by the last ``codex login``.  Falls back to the
-    login method declared in ``config.toml``, then to ``OPENAI_API_KEY`` in the
-    environment, then to ``unknown`` (which keeps the plan-based budget gate
-    active).
+    login method declared in ``config.toml``, then to what ``codex login
+    status`` reports, then to ``OPENAI_API_KEY`` in the environment, then to
+    ``unknown`` (which keeps the plan-based budget gate active).
     """
     if home is None:
         home = codex_home()
@@ -110,13 +156,20 @@ def detect_auth_mode(home: Path | None = None) -> str:
             return AUTH_MODE_APIKEY
 
     # auth.json can be missing entirely when Codex keeps credentials in the OS
-    # keyring (``cli_auth_credentials_store``); config.toml still records the
-    # login method, so consult it before giving up on the file layout.  A mode
-    # declared here is as authoritative as auth.json — an ambient
-    # OPENAI_API_KEY must not override a keyring-backed ChatGPT login.
+    # keyring (``cli_auth_credentials_store``); config.toml may still declare
+    # the login method, so consult it before giving up on the file layout.
+    # ``forced_login_method`` constrains which login Codex will use, so it
+    # outranks an ambient OPENAI_API_KEY left there for other tools.
     config_mode = _config_auth_mode(home)
     if config_mode is not None:
         return config_mode
+
+    # Nothing on disk names the login, which is normal for a keyring-backed
+    # one.  Ask Codex itself before falling back to guessing from the
+    # environment.
+    status_mode = _login_status_auth_mode(home)
+    if status_mode is not None:
+        return status_mode
 
     if os.environ.get("OPENAI_API_KEY", "").strip():
         return AUTH_MODE_APIKEY

--- a/src/mr_overkill/budget/codex.py
+++ b/src/mr_overkill/budget/codex.py
@@ -8,13 +8,62 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
-from mr_overkill.budget import budget_sufficient, codex_parse_window
+from mr_overkill.budget import (
+    FIVE_HOUR_WINDOW,
+    SEVEN_DAY_WINDOW,
+    budget_sufficient,
+    codex_parse_window,
+    codex_window_kind,
+)
 from mr_overkill.models import BudgetScope, BudgetStatus
 
 logger = logging.getLogger(__name__)
+
+# Codex auth modes, as written to ``auth.json`` by ``codex login``.
+AUTH_MODE_APIKEY = "apikey"
+AUTH_MODE_CHATGPT = "chatgpt"
+AUTH_MODE_UNKNOWN = "unknown"
+
+
+def codex_home() -> Path:
+    """Return the Codex config directory (``$CODEX_HOME`` or ``~/.codex``)."""
+    raw = os.environ.get("CODEX_HOME", "").strip()
+    return Path(raw) if raw else Path.home() / ".codex"
+
+
+def detect_auth_mode(home: Path | None = None) -> str:
+    """Detect how the Codex CLI authenticates.
+
+    ``auth.json`` is authoritative: it records the mode chosen by the last
+    ``codex login``.  Falls back to ``OPENAI_API_KEY`` in the environment,
+    then to ``unknown`` (which keeps the plan-based budget gate active).
+    """
+    if home is None:
+        home = codex_home()
+
+    try:
+        auth = json.loads((home / "auth.json").read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        auth = None
+
+    if isinstance(auth, dict):
+        mode = auth.get("auth_mode")
+        if isinstance(mode, str) and mode.strip():
+            return mode.strip().lower()
+        # Older Codex versions omit auth_mode; infer from the stored payload.
+        if auth.get("tokens"):
+            return AUTH_MODE_CHATGPT
+        if auth.get("OPENAI_API_KEY"):
+            return AUTH_MODE_APIKEY
+
+    if os.environ.get("OPENAI_API_KEY", "").strip():
+        return AUTH_MODE_APIKEY
+
+    return AUTH_MODE_UNKNOWN
 
 
 def find_latest_token_count(
@@ -25,7 +74,7 @@ def find_latest_token_count(
     Returns the event dict, or ``None`` if no data found.
     """
     if sessions_dir is None:
-        sessions_dir = Path.home() / ".codex" / "sessions"
+        sessions_dir = codex_home() / "sessions"
 
     if not sessions_dir.is_dir():
         return None
@@ -65,8 +114,36 @@ def find_latest_token_count(
     return best_event
 
 
-def check_token_budget(sessions_dir: Path | None = None) -> BudgetStatus:
-    """Get Codex budget status from session logs."""
+def check_token_budget(
+    sessions_dir: Path | None = None,
+    home: Path | None = None,
+) -> BudgetStatus:
+    """Get Codex budget status from session logs.
+
+    API-key auth is billed per token and carries no plan rate-limit windows,
+    so no budget data is reported for it — session logs written under a
+    previous ChatGPT login would otherwise gate the loop indefinitely.
+    """
+    if home is None:
+        # Session logs live at <codex_home>/sessions; callers that override
+        # only sessions_dir (tests, custom layouts) get the matching home.
+        home = sessions_dir.parent if sessions_dir is not None else codex_home()
+
+    auth_mode = detect_auth_mode(home)
+    if auth_mode == AUTH_MODE_APIKEY:
+        logger.info(
+            "Codex is on API-key auth — no plan rate limits to check.",
+        )
+        return BudgetStatus(
+            five_hour_used_pct=None,
+            seven_day_used_pct=None,
+            tokens_used=0,
+            mode=AUTH_MODE_APIKEY,
+            tier="",
+            resets_at=None,
+            seven_day_resets_at=None,
+        )
+
     event = find_latest_token_count(sessions_dir)
 
     if event is None:
@@ -87,14 +164,15 @@ def check_token_budget(sessions_dir: Path | None = None) -> BudgetStatus:
     primary = rate_limits.get("primary") if isinstance(rate_limits, dict) else None
     secondary = rate_limits.get("secondary") if isinstance(rate_limits, dict) else None
 
-    five_pct, five_resets = codex_parse_window(
-        primary if isinstance(primary, dict) else None,
+    windows = _map_windows(
+        (
+            (primary, FIVE_HOUR_WINDOW),
+            (secondary, SEVEN_DAY_WINDOW),
+        ),
         now_epoch,
     )
-    seven_pct, seven_resets = codex_parse_window(
-        secondary if isinstance(secondary, dict) else None,
-        now_epoch,
-    )
+    five_pct, five_resets = windows.get(FIVE_HOUR_WINDOW, (None, None))
+    seven_pct, seven_resets = windows.get(SEVEN_DAY_WINDOW, (None, None))
 
     return BudgetStatus(
         five_hour_used_pct=five_pct,
@@ -107,6 +185,37 @@ def check_token_budget(sessions_dir: Path | None = None) -> BudgetStatus:
     )
 
 
+def _map_windows(
+    slots: tuple[tuple[object, str], ...],
+    now_epoch: int,
+) -> dict[str, tuple[int | None, str | None]]:
+    """Assign Codex rate-limit windows to their BudgetStatus fields.
+
+    Each ``(window, positional_kind)`` pair is classified by the window's own
+    ``window_minutes``; the positional kind is only a fallback for payloads
+    that omit it.  When two windows land on the same kind, the higher usage
+    wins so the gate stays conservative.
+    """
+    mapped: dict[str, tuple[int | None, str | None]] = {}
+
+    for window, positional_kind in slots:
+        if not isinstance(window, dict) or not window:
+            continue
+
+        kind = codex_window_kind(window) or positional_kind
+        pct, resets = codex_parse_window(window, now_epoch)
+
+        previous = mapped.get(kind)
+        if previous is not None:
+            prev_pct = previous[0]
+            if pct is None or (prev_pct is not None and prev_pct >= pct):
+                continue
+
+        mapped[kind] = (pct, resets)
+
+    return mapped
+
+
 def codex_budget_sufficient(
     scope: BudgetScope,
     status: BudgetStatus | None = None,
@@ -115,4 +224,6 @@ def codex_budget_sufficient(
     """Go/no-go for Codex at the given scope."""
     if status is None:
         status = check_token_budget(sessions_dir)
+    if status.mode == AUTH_MODE_APIKEY:
+        return True
     return budget_sufficient(scope, status)

--- a/src/mr_overkill/budget/codex.py
+++ b/src/mr_overkill/budget/codex.py
@@ -34,8 +34,14 @@ AUTH_MODE_UNKNOWN = "unknown"
 # older one and still sits in configs written by earlier versions.
 _CONFIG_AUTH_KEYS = ("forced_login_method", "preferred_auth_method")
 
-# Spellings of API-key auth seen across auth.json and config.toml.
-_APIKEY_ALIASES = frozenset({"apikey", "api_key", "api-key"})
+# Login-method spellings seen across auth.json and config.toml, mapped to the
+# canonical mode the budget gate compares against.
+_AUTH_MODE_ALIASES = {
+    "apikey": AUTH_MODE_APIKEY,
+    "api_key": AUTH_MODE_APIKEY,
+    "api-key": AUTH_MODE_APIKEY,
+    "chatgpt": AUTH_MODE_CHATGPT,
+}
 
 
 def codex_home() -> Path:
@@ -47,8 +53,9 @@ def codex_home() -> Path:
 def _config_auth_mode(home: Path) -> str | None:
     """Return the login method declared in ``config.toml``, or ``None``.
 
-    Only API-key auth is reported: every other value leaves the plan-based
-    budget gate active, which is what the caller already defaults to.
+    Only recognised spellings are reported, so ``None`` means "the config
+    declares no login method we know" — which is what lets the caller tell an
+    explicit ChatGPT setup apart from a config that says nothing at all.
     """
     try:
         with (home / "config.toml").open("rb") as handle:
@@ -58,8 +65,10 @@ def _config_auth_mode(home: Path) -> str | None:
 
     for key in _CONFIG_AUTH_KEYS:
         value = config.get(key)
-        if isinstance(value, str) and value.strip().lower() in _APIKEY_ALIASES:
-            return AUTH_MODE_APIKEY
+        if isinstance(value, str):
+            mode = _AUTH_MODE_ALIASES.get(value.strip().lower())
+            if mode is not None:
+                return mode
 
     return None
 
@@ -90,7 +99,10 @@ def detect_auth_mode(home: Path | None = None) -> str:
     if isinstance(auth, dict):
         mode = auth.get("auth_mode")
         if isinstance(mode, str) and mode.strip():
-            return mode.strip().lower()
+            # Unrecognised spellings pass through as-is: they are not the
+            # API-key mode the gate bypasses, so the gate stays active.
+            spelling = mode.strip().lower()
+            return _AUTH_MODE_ALIASES.get(spelling, spelling)
         # Older Codex versions omit auth_mode; infer from the stored payload.
         if auth.get("tokens"):
             return AUTH_MODE_CHATGPT
@@ -99,9 +111,12 @@ def detect_auth_mode(home: Path | None = None) -> str:
 
     # auth.json can be missing entirely when Codex keeps credentials in the OS
     # keyring (``cli_auth_credentials_store``); config.toml still records the
-    # login method, so consult it before giving up on the file layout.
-    if _config_auth_mode(home) == AUTH_MODE_APIKEY:
-        return AUTH_MODE_APIKEY
+    # login method, so consult it before giving up on the file layout.  A mode
+    # declared here is as authoritative as auth.json — an ambient
+    # OPENAI_API_KEY must not override a keyring-backed ChatGPT login.
+    config_mode = _config_auth_mode(home)
+    if config_mode is not None:
+        return config_mode
 
     if os.environ.get("OPENAI_API_KEY", "").strip():
         return AUTH_MODE_APIKEY

--- a/src/mr_overkill/budget/codex.py
+++ b/src/mr_overkill/budget/codex.py
@@ -109,12 +109,14 @@ def _login_status_auth_mode(home: Path) -> str | None:
         return None
 
     # Codex prints the status line on stderr; stdout is checked too so a later
-    # version moving it there keeps working.
+    # version moving it there keeps working.  Every line is examined because a
+    # warning or banner ahead of the status line must not hide it.
     for stream in (result.stderr, result.stdout):
-        status = stream.strip().lower()
-        for prefix, mode in _LOGIN_STATUS_MODES:
-            if status.startswith(prefix):
-                return mode
+        for line in stream.splitlines():
+            status = line.strip().lower()
+            for prefix, mode in _LOGIN_STATUS_MODES:
+                if status.startswith(prefix):
+                    return mode
 
     return None
 

--- a/src/mr_overkill/budget_report.py
+++ b/src/mr_overkill/budget_report.py
@@ -6,8 +6,14 @@ import json
 import sys
 from dataclasses import asdict
 
-from mr_overkill.budget import budget_sufficient, has_threshold
+from mr_overkill.budget import (
+    SKIP_BUDGET_ENV_VAR,
+    budget_gate_disabled,
+    budget_sufficient,
+    has_threshold,
+)
 from mr_overkill.budget.claude import check_token_budget as claude_check
+from mr_overkill.budget.codex import AUTH_MODE_APIKEY
 from mr_overkill.budget.codex import check_token_budget as codex_check
 from mr_overkill.models import BudgetScope, BudgetStatus
 
@@ -47,6 +53,10 @@ def _print_codex(status: BudgetStatus) -> None:
     print("Codex Token Budget")
     print(_HEADER)
     print(f"  Mode:     {status.mode}")
+    if status.mode == AUTH_MODE_APIKEY:
+        print("  No plan rate limits (API-key billing).")
+        print()
+        return
     print(
         f"  5h used:  {_fmt_pct(status.five_hour_used_pct)}"
         f"{_fmt_reset(status.resets_at)}"
@@ -73,13 +83,23 @@ def _print_scope_table(claude_st: BudgetStatus, codex_st: BudgetStatus) -> None:
         BudgetScope.MICRO, BudgetScope.MODULE,
         BudgetScope.LAYER, BudgetScope.FULL,
     )
+    gate_off = budget_gate_disabled()
     for scope in scopes:
-        if has_threshold(scope):
-            c_label = "GO" if budget_sufficient(scope, claude_st) else "NOGO"
-            x_label = "GO" if budget_sufficient(scope, codex_st) else "NOGO"
-        else:
+        if not has_threshold(scope):
             c_label = x_label = "—"
+        else:
+            c_label = "GO" if gate_off or budget_sufficient(
+                scope, claude_st
+            ) else "NOGO"
+            codex_go = (
+                gate_off
+                or codex_st.mode == AUTH_MODE_APIKEY
+                or budget_sufficient(scope, codex_st)
+            )
+            x_label = "GO" if codex_go else "NOGO"
         print(f"  {scope.value:<8} {c_label:<7} {x_label:<7} —")
+    if gate_off:
+        print(f"  (all GO: {SKIP_BUDGET_ENV_VAR} is set)")
 
 
 def print_budget_report(*, json_mode: bool = False) -> int:

--- a/src/mr_overkill/cli.py
+++ b/src/mr_overkill/cli.py
@@ -108,11 +108,12 @@ def _load_rc_file(rc_name: str) -> dict[str, str]:
         "RETRY_INITIAL_WAIT", "BUDGET_SCOPE", "DIAGNOSTIC_LOG",
         "SCOPE", "AUTO_APPROVE", "CREATE_PR", "WITH_REVIEW",
         "REVIEW_LOOPS", "FIX_NITS", "REVIEWER_BACKEND",
-        "REVIEWER_CONTEXT", "CI_TRIGGER_MODE",
+        "REVIEWER_CONTEXT", "CI_TRIGGER_MODE", "NO_BUDGET_GATE",
     }
     boolean_keys = {
         "DRY_RUN", "AUTO_COMMIT", "DIAGNOSTIC_LOG",
         "AUTO_APPROVE", "CREATE_PR", "WITH_REVIEW", "FIX_NITS",
+        "NO_BUDGET_GATE",
     }
     kv_re = re.compile(
         r"""^\s*(\w+)=(?:"([^"]*)"|'([^']*)'|(.*?))\s*$"""

--- a/src/mr_overkill/cli.py
+++ b/src/mr_overkill/cli.py
@@ -296,6 +296,16 @@ def parse_review_loop_args(
         help="Save full event stream to sidecar files",
     )
     parser.add_argument(
+        "--no-budget-gate",
+        action="store_true",
+        default=None,
+        help=(
+            "Skip token-budget checks and run the CLI backends regardless. "
+            "Use when local budget data is stale or wrong "
+            "(same as OVERKILL_SKIP_BUDGET=1)"
+        ),
+    )
+    parser.add_argument(
         "--reviewer-backend",
         default=None,
         choices=["claude", "codex", "gemini"],
@@ -355,6 +365,9 @@ def parse_review_loop_args(
     diagnostic_log = args.diagnostic_log or rc.get(
         "DIAGNOSTIC_LOG", "false"
     ) == "true"
+    skip_budget_gate = _resolve_bool(
+        args.no_budget_gate, rc.get("NO_BUDGET_GATE"), False
+    )
 
     retry_max_wait = _int_from_rc(rc, "RETRY_MAX_WAIT", "7200", parser)
     retry_initial_wait = _int_from_rc(rc, "RETRY_INITIAL_WAIT", "30", parser)
@@ -462,6 +475,7 @@ def parse_review_loop_args(
             budget_scope_str, parser,
             allowed=frozenset({BudgetScope.MICRO, BudgetScope.MODULE}),
         ),
+        skip_budget_gate=skip_budget_gate,
         diagnostic_log=diagnostic_log,
         log_dir=log_dir,
         prompts_dir=prompts_dir,
@@ -569,6 +583,16 @@ def parse_refactor_suggest_args(
         help="Save full event stream to sidecar files",
     )
     parser.add_argument(
+        "--no-budget-gate",
+        action="store_true",
+        default=None,
+        help=(
+            "Skip token-budget checks and run the CLI backends regardless. "
+            "Use when local budget data is stale or wrong "
+            "(same as OVERKILL_SKIP_BUDGET=1)"
+        ),
+    )
+    parser.add_argument(
         "--with-review",
         action="store_true",
         default=None,
@@ -626,6 +650,9 @@ def parse_refactor_suggest_args(
     diagnostic_log = args.diagnostic_log or rc.get(
         "DIAGNOSTIC_LOG", "false"
     ) == "true"
+    skip_budget_gate = _resolve_bool(
+        args.no_budget_gate, rc.get("NO_BUDGET_GATE"), False
+    )
 
     with_review = _resolve_bool(args.with_review, rc.get("WITH_REVIEW"), False)
     review_loops = (
@@ -736,6 +763,7 @@ def parse_refactor_suggest_args(
             budget_scope_str, parser,
             allowed=frozenset({BudgetScope.MICRO, BudgetScope.MODULE}),
         ),
+        skip_budget_gate=skip_budget_gate,
         diagnostic_log=diagnostic_log,
         log_dir=log_dir,
         prompts_dir=prompts_dir,

--- a/src/mr_overkill/models.py
+++ b/src/mr_overkill/models.py
@@ -79,7 +79,7 @@ class BudgetStatus:
     five_hour_used_pct: int | None
     seven_day_used_pct: int | None
     tokens_used: int  # weighted sum for local estimation (not raw count)
-    mode: str  # "oauth" | "local" | "session_log" | "no_data"
+    mode: str  # "oauth" | "local" | "session_log" | "apikey" | "no_data"
     tier: str  # "pro" | "max5" | "max20"
     resets_at: str | None
     seven_day_resets_at: str | None = None
@@ -174,6 +174,7 @@ class LoopConfig:
     retry_max_wait: int = 7200
     retry_initial_wait: int = 30
     budget_scope: BudgetScope = BudgetScope.MICRO
+    skip_budget_gate: bool = False
     diagnostic_log: bool = False
 
     # Paths

--- a/src/mr_overkill/refactor_suggest.py
+++ b/src/mr_overkill/refactor_suggest.py
@@ -15,7 +15,7 @@ from mr_overkill.agents import (
     create_review_agent,
     create_self_review_agent,
 )
-from mr_overkill.budget import budget_sufficient
+from mr_overkill.budget import budget_gate_disabled, budget_sufficient
 from mr_overkill.budget.claude import check_token_budget as claude_budget
 from mr_overkill.budget.codex import check_token_budget as codex_budget
 from mr_overkill.git_ops import git_all_dirty, stash_allowlisted, unstash_allowlisted
@@ -40,6 +40,10 @@ def resolve_auto_scope(
 
     Returns ``'module'``, ``'micro'``, or ``None`` if budget is too low.
     """
+    if budget_gate_disabled():
+        logger.info("Budget gate disabled — resolving 'auto' scope to 'module'.")
+        return "module"
+
     if tools is None:
         tools = ["claude", "codex"]
 

--- a/src/mr_overkill/refactor_suggest.py
+++ b/src/mr_overkill/refactor_suggest.py
@@ -35,12 +35,14 @@ logger = logging.getLogger(__name__)
 
 def resolve_auto_scope(
     tools: list[str] | None = None,
+    *,
+    skip_gate: bool = False,
 ) -> str | None:
     """Resolve 'auto' scope based on current budget levels.
 
     Returns ``'module'``, ``'micro'``, or ``None`` if budget is too low.
     """
-    if budget_gate_disabled():
+    if skip_gate or budget_gate_disabled():
         logger.info("Budget gate disabled — resolving 'auto' scope to 'module'.")
         return "module"
 
@@ -320,7 +322,9 @@ def run(config: LoopConfig, scope: str, *, create_pr: bool = False) -> int:
             tools = ["claude"]
             if config.reviewer_backend in ("codex", "gemini"):
                 tools.append(config.reviewer_backend)
-        resolved = resolve_auto_scope(tools=tools)
+        resolved = resolve_auto_scope(
+            tools=tools, skip_gate=config.skip_budget_gate,
+        )
         if resolved is None:
             logger.error("Budget too low for any refactor scope.")
             return 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,18 @@ import pytest
 from mr_overkill.models import LoopConfig
 
 
+@pytest.fixture(autouse=True)
+def _isolate_budget_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep budget detection independent of the developer's own environment.
+
+    ``OPENAI_API_KEY``/``CODEX_HOME`` change which auth mode is detected and
+    ``OVERKILL_SKIP_BUDGET`` bypasses the gate entirely, so tests would pass
+    or fail depending on the shell they run in.
+    """
+    for var in ("OPENAI_API_KEY", "CODEX_HOME", "OVERKILL_SKIP_BUDGET"):
+        monkeypatch.delenv(var, raising=False)
+
+
 @pytest.fixture()
 def tmp_git_repo(tmp_path: Path) -> Path:
     """Create a minimal git repository in a temporary directory.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,11 +16,16 @@ from mr_overkill.models import LoopConfig
 def _isolate_budget_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Keep budget detection independent of the developer's own environment.
 
-    ``OPENAI_API_KEY``/``CODEX_HOME`` change which auth mode is detected and
-    ``OVERKILL_SKIP_BUDGET`` bypasses the gate entirely, so tests would pass
-    or fail depending on the shell they run in.
+    ``CODEX_API_KEY``/``OPENAI_API_KEY``/``CODEX_HOME`` change which auth mode
+    is detected and ``OVERKILL_SKIP_BUDGET`` bypasses the gate entirely, so
+    tests would pass or fail depending on the shell they run in.
     """
-    for var in ("OPENAI_API_KEY", "CODEX_HOME", "OVERKILL_SKIP_BUDGET"):
+    for var in (
+        "CODEX_API_KEY",
+        "OPENAI_API_KEY",
+        "CODEX_HOME",
+        "OVERKILL_SKIP_BUDGET",
+    ):
         monkeypatch.delenv(var, raising=False)
 
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -7,6 +7,8 @@ from collections.abc import Callable
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from mr_overkill.agents import (
     ClaudeFixAgent,
     ClaudeRefactorReviewAgent,
@@ -19,6 +21,7 @@ from mr_overkill.agents import (
     GeminiReviewAgent,
     ReviewAgent,
     SelfReviewAgent,
+    _budget_check,
     _BudgetFn,
     create_fix_agent,
     create_review_agent,
@@ -469,6 +472,42 @@ class TestBudgetFn:
 
         _, _, _, actual_wait = mock_wait.call_args[0]
         assert actual_wait == 9999
+
+    @patch("mr_overkill.agents.wait_for_budget", return_value=False)
+    def test_skip_budget_gate_bypasses_wait(
+        self,
+        mock_wait: MagicMock,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        config = make_loop_config(skip_budget_gate=True)
+        fn = _BudgetFn(config)
+
+        assert fn("codex", BudgetScope.MICRO, 0) is True
+        mock_wait.assert_not_called()
+
+
+class TestBudgetCheckEnvOverride:
+    @patch("mr_overkill.agents.codex_budget_sufficient", return_value=False)
+    def test_env_var_bypasses_check(
+        self,
+        mock_codex: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("OVERKILL_SKIP_BUDGET", "1")
+
+        assert _budget_check("codex", BudgetScope.MICRO, 0) is True
+        mock_codex.assert_not_called()
+
+    @patch("mr_overkill.agents.codex_budget_sufficient", return_value=False)
+    def test_check_runs_without_env_var(
+        self,
+        mock_codex: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("OVERKILL_SKIP_BUDGET", raising=False)
+
+        assert _budget_check("codex", BudgetScope.MICRO, 0) is False
+        mock_codex.assert_called_once()
 
 
 # ── Factory functions ────────────────────────────────────────────────

--- a/tests/test_budget_codex.py
+++ b/tests/test_budget_codex.py
@@ -389,6 +389,20 @@ class TestLoginStatusProbe:
         monkeypatch.setattr(subprocess, "run", raise_oserror)
         assert detect_auth_mode(tmp_path) == AUTH_MODE_UNKNOWN
 
+    def test_a_hung_probe_keeps_the_gate_active(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A keychain prompt on a non-interactive run would otherwise block the
+        # budget poll forever, so the probe must be bounded and give up quietly.
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        def raise_timeout(cmd: list[str], **kwargs: object) -> None:
+            assert kwargs["timeout"]
+            raise subprocess.TimeoutExpired(cmd, 5)
+
+        monkeypatch.setattr(subprocess, "run", raise_timeout)
+        assert detect_auth_mode(tmp_path) == AUTH_MODE_UNKNOWN
+
     def test_config_login_method_wins_over_the_probe(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_budget_codex.py
+++ b/tests/test_budget_codex.py
@@ -186,6 +186,47 @@ class TestDetectAuthMode:
         (tmp_path / "auth.json").write_text(json.dumps({"auth_mode": "chatgpt"}))
         assert detect_auth_mode(tmp_path) == AUTH_MODE_CHATGPT
 
+    def test_config_login_method_when_credentials_are_in_the_keyring(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # No auth.json at all: Codex stored the login in the OS keyring.
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        (tmp_path / "config.toml").write_text(
+            'cli_auth_credentials_store = "keyring"\nforced_login_method = "apikey"\n'
+        )
+        assert detect_auth_mode(tmp_path) == AUTH_MODE_APIKEY
+
+    def test_legacy_config_auth_key(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        (tmp_path / "config.toml").write_text('preferred_auth_method = "apikey"\n')
+        assert detect_auth_mode(tmp_path) == AUTH_MODE_APIKEY
+
+    def test_config_chatgpt_login_keeps_gate_active(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        (tmp_path / "config.toml").write_text('forced_login_method = "chatgpt"\n')
+        assert detect_auth_mode(tmp_path) == AUTH_MODE_UNKNOWN
+
+    def test_auth_file_wins_over_config_login_method(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # config.toml only records intent; a cached ChatGPT login is what Codex
+        # actually sends, so plan rate limits still apply.
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        (tmp_path / "auth.json").write_text(json.dumps({"auth_mode": "chatgpt"}))
+        (tmp_path / "config.toml").write_text('forced_login_method = "apikey"\n')
+        assert detect_auth_mode(tmp_path) == AUTH_MODE_CHATGPT
+
+    def test_malformed_config_falls_back(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        (tmp_path / "config.toml").write_text("not = = toml")
+        assert detect_auth_mode(tmp_path) == AUTH_MODE_UNKNOWN
+
     def test_malformed_auth_file_falls_back(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_budget_codex.py
+++ b/tests/test_budget_codex.py
@@ -6,7 +6,35 @@ import json
 from datetime import UTC, datetime
 from pathlib import Path
 
-from mr_overkill.budget.codex import check_token_budget, find_latest_token_count
+import pytest
+
+from mr_overkill.budget.codex import (
+    AUTH_MODE_APIKEY,
+    AUTH_MODE_CHATGPT,
+    AUTH_MODE_UNKNOWN,
+    check_token_budget,
+    codex_budget_sufficient,
+    codex_home,
+    detect_auth_mode,
+    find_latest_token_count,
+)
+from mr_overkill.models import BudgetScope
+
+
+def _write_session(
+    sessions: Path,
+    rate_limits: dict[str, object],
+    timestamp: object = 1000,
+) -> None:
+    """Write a single token_count event into today's session directory."""
+    day_dir = sessions / datetime.now(tz=UTC).strftime("%Y/%m/%d")
+    day_dir.mkdir(parents=True, exist_ok=True)
+    event = {
+        "type": "event_msg",
+        "timestamp": timestamp,
+        "payload": {"type": "token_count", "rate_limits": rate_limits},
+    }
+    (day_dir / "session.jsonl").write_text(json.dumps(event) + "\n")
 
 
 class TestFindLatestTokenCount:
@@ -104,3 +132,197 @@ class TestCheckTokenBudget:
         assert status.mode == "session_log"
         assert status.five_hour_used_pct == 45
         assert status.resets_at is not None
+
+
+# ── auth-mode detection ──────────────────────────────────────────────
+
+
+class TestDetectAuthMode:
+    def test_no_auth_file_without_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        assert detect_auth_mode(tmp_path) == AUTH_MODE_UNKNOWN
+
+    def test_explicit_apikey_mode(self, tmp_path: Path) -> None:
+        (tmp_path / "auth.json").write_text(
+            json.dumps({"auth_mode": "apikey", "OPENAI_API_KEY": "sk-test"})
+        )
+        assert detect_auth_mode(tmp_path) == AUTH_MODE_APIKEY
+
+    def test_explicit_chatgpt_mode(self, tmp_path: Path) -> None:
+        (tmp_path / "auth.json").write_text(json.dumps({"auth_mode": "chatgpt"}))
+        assert detect_auth_mode(tmp_path) == AUTH_MODE_CHATGPT
+
+    def test_infers_chatgpt_from_tokens(self, tmp_path: Path) -> None:
+        (tmp_path / "auth.json").write_text(
+            json.dumps({"tokens": {"access_token": "x"}})
+        )
+        assert detect_auth_mode(tmp_path) == AUTH_MODE_CHATGPT
+
+    def test_infers_apikey_from_stored_key(self, tmp_path: Path) -> None:
+        (tmp_path / "auth.json").write_text(json.dumps({"OPENAI_API_KEY": "sk-test"}))
+        assert detect_auth_mode(tmp_path) == AUTH_MODE_APIKEY
+
+    def test_env_fallback_when_no_auth_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        assert detect_auth_mode(tmp_path) == AUTH_MODE_APIKEY
+
+    def test_malformed_auth_file_falls_back(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        (tmp_path / "auth.json").write_text("{not json")
+        assert detect_auth_mode(tmp_path) == AUTH_MODE_UNKNOWN
+
+    def test_codex_home_respects_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CODEX_HOME", "/custom/codex")
+        assert codex_home() == Path("/custom/codex")
+
+
+class TestApiKeyMode:
+    def test_ignores_stale_session_logs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A pre-API-key ChatGPT session log must not gate API-key runs."""
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        (tmp_path / "auth.json").write_text(json.dumps({"auth_mode": "apikey"}))
+        sessions = tmp_path / "sessions"
+        now = int(datetime.now(tz=UTC).timestamp())
+        _write_session(
+            sessions,
+            {
+                "primary": {
+                    "used_percent": 90.0,
+                    "window_minutes": 10080,
+                    "resets_at": now + 86400,
+                },
+            },
+        )
+
+        status = check_token_budget(sessions)
+
+        assert status.mode == AUTH_MODE_APIKEY
+        assert status.five_hour_used_pct is None
+        assert status.seven_day_used_pct is None
+        assert codex_budget_sufficient(BudgetScope.MICRO, status) is True
+        assert codex_budget_sufficient(BudgetScope.MODULE, status) is True
+
+    def test_chatgpt_mode_still_reads_session_logs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        (tmp_path / "auth.json").write_text(json.dumps({"auth_mode": "chatgpt"}))
+        sessions = tmp_path / "sessions"
+        now = int(datetime.now(tz=UTC).timestamp())
+        _write_session(
+            sessions,
+            {
+                "primary": {
+                    "used_percent": 80.0,
+                    "window_minutes": 300,
+                    "resets_at": now + 3600,
+                },
+            },
+        )
+
+        status = check_token_budget(sessions)
+
+        assert status.mode == "session_log"
+        assert status.five_hour_used_pct == 80
+
+
+# ── window mapping by declared length ────────────────────────────────
+
+
+class TestWindowMapping:
+    def test_weekly_primary_maps_to_seven_day(self, tmp_path: Path) -> None:
+        """Codex sends the weekly limit as `primary` on some plans."""
+        sessions = tmp_path / "sessions"
+        now = int(datetime.now(tz=UTC).timestamp())
+        _write_session(
+            sessions,
+            {
+                "primary": {
+                    "used_percent": 90.0,
+                    "window_minutes": 10080,
+                    "resets_at": now + 86400,
+                },
+                "secondary": None,
+            },
+        )
+
+        status = check_token_budget(sessions)
+
+        assert status.seven_day_used_pct == 90
+        assert status.five_hour_used_pct is None
+        assert status.seven_day_resets_at is not None
+        # 7-day at 90 % does not block micro scope — only module and above.
+        assert codex_budget_sufficient(BudgetScope.MICRO, status) is True
+        assert codex_budget_sufficient(BudgetScope.MODULE, status) is False
+
+    def test_swapped_windows_are_reordered(self, tmp_path: Path) -> None:
+        sessions = tmp_path / "sessions"
+        now = int(datetime.now(tz=UTC).timestamp())
+        _write_session(
+            sessions,
+            {
+                "primary": {
+                    "used_percent": 70.0,
+                    "window_minutes": 10080,
+                    "resets_at": now + 86400,
+                },
+                "secondary": {
+                    "used_percent": 20.0,
+                    "window_minutes": 300,
+                    "resets_at": now + 3600,
+                },
+            },
+        )
+
+        status = check_token_budget(sessions)
+
+        assert status.five_hour_used_pct == 20
+        assert status.seven_day_used_pct == 70
+
+    def test_missing_window_minutes_uses_position(self, tmp_path: Path) -> None:
+        sessions = tmp_path / "sessions"
+        now = int(datetime.now(tz=UTC).timestamp())
+        _write_session(
+            sessions,
+            {
+                "primary": {"used_percent": 30.0, "resets_at": now + 3600},
+                "secondary": {"used_percent": 60.0, "resets_at": now + 86400},
+            },
+        )
+
+        status = check_token_budget(sessions)
+
+        assert status.five_hour_used_pct == 30
+        assert status.seven_day_used_pct == 60
+
+    def test_two_windows_same_kind_keeps_higher(self, tmp_path: Path) -> None:
+        sessions = tmp_path / "sessions"
+        now = int(datetime.now(tz=UTC).timestamp())
+        _write_session(
+            sessions,
+            {
+                "primary": {
+                    "used_percent": 40.0,
+                    "window_minutes": 10080,
+                    "resets_at": now + 86400,
+                },
+                "secondary": {
+                    "used_percent": 65.0,
+                    "window_minutes": 20160,
+                    "resets_at": now + 86400,
+                },
+            },
+        )
+
+        status = check_token_budget(sessions)
+
+        assert status.seven_day_used_pct == 65
+        assert status.five_hour_used_pct is None

--- a/tests/test_budget_codex.py
+++ b/tests/test_budget_codex.py
@@ -333,6 +333,18 @@ class TestLoginStatusProbe:
         _stub_login_status(monkeypatch, status, stream=stream)
         assert detect_auth_mode(tmp_path) == expected
 
+    def test_a_warning_ahead_of_the_status_line_is_skipped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Codex may print a warning first; the status line still has to be read.
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        _stub_login_status(
+            monkeypatch,
+            "warning: config.toml: unknown key `foo`\n"
+            "Logged in using an API key - sk-proj-***abcde",
+        )
+        assert detect_auth_mode(tmp_path) == AUTH_MODE_APIKEY
+
     def test_chatgpt_login_beats_an_ambient_openai_api_key(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_budget_codex.py
+++ b/tests/test_budget_codex.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
 
+from mr_overkill.budget import codex as codex_budget
 from mr_overkill.budget.codex import (
     AUTH_MODE_APIKEY,
     AUTH_MODE_CHATGPT,
@@ -19,6 +21,20 @@ from mr_overkill.budget.codex import (
     find_latest_token_count,
 )
 from mr_overkill.models import BudgetScope
+
+# Captured before any test patches it, so the probe's own tests can restore it.
+_REAL_LOGIN_STATUS_PROBE = codex_budget._login_status_auth_mode
+
+
+@pytest.fixture(autouse=True)
+def _no_login_status_probe(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep ``codex login status`` out of the tests that predate the probe.
+
+    Detection falls through to it whenever nothing on disk names the login, so
+    without this every such test would spawn the real CLI.  Tests that cover
+    the probe restore it explicitly.
+    """
+    monkeypatch.setattr(codex_budget, "_login_status_auth_mode", lambda home: None)
 
 
 def _write_session(
@@ -201,7 +217,7 @@ class TestDetectAuthMode:
         # No auth.json at all: Codex stored the login in the OS keyring.
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         (tmp_path / "config.toml").write_text(
-            'cli_auth_credentials_store = "keyring"\nforced_login_method = "apikey"\n'
+            'cli_auth_credentials_store = "keyring"\nforced_login_method = "api"\n'
         )
         assert detect_auth_mode(tmp_path) == AUTH_MODE_APIKEY
 
@@ -238,7 +254,7 @@ class TestDetectAuthMode:
         # actually sends, so plan rate limits still apply.
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         (tmp_path / "auth.json").write_text(json.dumps({"auth_mode": "chatgpt"}))
-        (tmp_path / "config.toml").write_text('forced_login_method = "apikey"\n')
+        (tmp_path / "config.toml").write_text('forced_login_method = "api"\n')
         assert detect_auth_mode(tmp_path) == AUTH_MODE_CHATGPT
 
     def test_malformed_config_falls_back(
@@ -258,6 +274,131 @@ class TestDetectAuthMode:
     def test_codex_home_respects_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("CODEX_HOME", "/custom/codex")
         assert codex_home() == Path("/custom/codex")
+
+
+# ── keyring logins, read back from ``codex login status`` ────────────
+
+
+def _stub_login_status(
+    monkeypatch: pytest.MonkeyPatch,
+    status: str,
+    returncode: int = 0,
+    stream: str = "stderr",
+) -> None:
+    """Make ``codex login status`` report ``status`` without running Codex.
+
+    Real Codex prints the status line on stderr, so that is the default.
+    """
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert cmd == ["codex", "login", "status"]
+        return subprocess.CompletedProcess(
+            cmd,
+            returncode,
+            status if stream == "stdout" else "",
+            status if stream == "stderr" else "",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+
+class TestLoginStatusProbe:
+    @pytest.fixture(autouse=True)
+    def _use_real_probe(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Put the real probe back: these tests are about the probe itself, and
+        # stub ``subprocess.run`` instead of the function under test.
+        monkeypatch.setattr(
+            codex_budget, "_login_status_auth_mode", _REAL_LOGIN_STATUS_PROBE
+        )
+
+    @pytest.mark.parametrize("stream", ["stderr", "stdout"])
+    @pytest.mark.parametrize(
+        ("status", "expected"),
+        [
+            ("Logged in using an API key - sk-proj-***abcde", AUTH_MODE_APIKEY),
+            ("Logged in using Amazon Bedrock API key", AUTH_MODE_APIKEY),
+            ("Logged in using ChatGPT", AUTH_MODE_CHATGPT),
+        ],
+    )
+    def test_reports_the_active_login(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        status: str,
+        expected: str,
+        stream: str,
+    ) -> None:
+        # A keyring-backed login leaves nothing on disk to read.
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        _stub_login_status(monkeypatch, status, stream=stream)
+        assert detect_auth_mode(tmp_path) == expected
+
+    def test_chatgpt_login_beats_an_ambient_openai_api_key(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The gate must not be switched off by the environment when Codex
+        # itself says the keyring holds a ChatGPT login.
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        _stub_login_status(monkeypatch, "Logged in using ChatGPT")
+        assert detect_auth_mode(tmp_path) == AUTH_MODE_CHATGPT
+
+    @pytest.mark.parametrize(
+        ("status", "returncode"),
+        [
+            ("Not logged in", 1),
+            ("Logged in using access token", 0),
+            ("", 0),
+        ],
+    )
+    def test_unreadable_logins_keep_the_gate_active(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        status: str,
+        returncode: int,
+    ) -> None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        _stub_login_status(monkeypatch, status, returncode)
+        assert detect_auth_mode(tmp_path) == AUTH_MODE_UNKNOWN
+
+    def test_missing_codex_binary_keeps_the_gate_active(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        def raise_oserror(cmd: list[str], **kwargs: object) -> None:
+            raise OSError("codex not found")
+
+        monkeypatch.setattr(subprocess, "run", raise_oserror)
+        assert detect_auth_mode(tmp_path) == AUTH_MODE_UNKNOWN
+
+    def test_config_login_method_wins_over_the_probe(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # config.toml forces the login method, so there is nothing to ask.
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        (tmp_path / "config.toml").write_text('forced_login_method = "chatgpt"\n')
+        _stub_login_status(monkeypatch, "Logged in using an API key - sk-x")
+        assert detect_auth_mode(tmp_path) == AUTH_MODE_CHATGPT
+
+    def test_probe_runs_against_the_given_codex_home(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        seen: dict[str, str] = {}
+
+        def fake_run(
+            cmd: list[str], **kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            env = kwargs["env"]
+            assert isinstance(env, dict)
+            seen.update(env)
+            return subprocess.CompletedProcess(cmd, 0, "", "Logged in using ChatGPT")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        detect_auth_mode(tmp_path)
+
+        assert seen["CODEX_HOME"] == str(tmp_path)
 
 
 class TestApiKeyMode:

--- a/tests/test_budget_codex.py
+++ b/tests/test_budget_codex.py
@@ -150,6 +150,15 @@ class TestDetectAuthMode:
         )
         assert detect_auth_mode(tmp_path) == AUTH_MODE_APIKEY
 
+    @pytest.mark.parametrize("spelling", ["api_key", "api-key", "APIKEY"])
+    def test_apikey_spellings_are_normalized(
+        self, tmp_path: Path, spelling: str
+    ) -> None:
+        # The gate compares against the canonical mode, so every spelling Codex
+        # may write has to arrive there normalized.
+        (tmp_path / "auth.json").write_text(json.dumps({"auth_mode": spelling}))
+        assert detect_auth_mode(tmp_path) == AUTH_MODE_APIKEY
+
     def test_explicit_chatgpt_mode(self, tmp_path: Path) -> None:
         (tmp_path / "auth.json").write_text(json.dumps({"auth_mode": "chatgpt"}))
         assert detect_auth_mode(tmp_path) == AUTH_MODE_CHATGPT
@@ -208,7 +217,19 @@ class TestDetectAuthMode:
     ) -> None:
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         (tmp_path / "config.toml").write_text('forced_login_method = "chatgpt"\n')
-        assert detect_auth_mode(tmp_path) == AUTH_MODE_UNKNOWN
+        assert detect_auth_mode(tmp_path) == AUTH_MODE_CHATGPT
+
+    def test_openai_api_key_loses_to_config_chatgpt_login(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Keyring-backed ChatGPT login: the config declares it explicitly, so
+        # an OPENAI_API_KEY left in the environment for other tools must not
+        # switch the gate off.
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        (tmp_path / "config.toml").write_text(
+            'cli_auth_credentials_store = "keyring"\nforced_login_method = "chatgpt"\n'
+        )
+        assert detect_auth_mode(tmp_path) == AUTH_MODE_CHATGPT
 
     def test_auth_file_wins_over_config_login_method(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_budget_codex.py
+++ b/tests/test_budget_codex.py
@@ -189,11 +189,14 @@ class TestDetectAuthMode:
         (tmp_path / "auth.json").write_text(json.dumps({"OPENAI_API_KEY": "sk-test"}))
         assert detect_auth_mode(tmp_path) == AUTH_MODE_APIKEY
 
-    def test_env_fallback_when_no_auth_file(
+    def test_env_openai_key_alone_is_not_an_active_login(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        # Codex does not authenticate with OPENAI_API_KEY, so a key left in the
+        # environment for other tools says nothing about the Codex login and
+        # must leave the plan-based gate active.
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
-        assert detect_auth_mode(tmp_path) == AUTH_MODE_APIKEY
+        assert detect_auth_mode(tmp_path) == AUTH_MODE_UNKNOWN
 
     def test_codex_api_key_overrides_chatgpt_auth_file(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -221,12 +224,14 @@ class TestDetectAuthMode:
         )
         assert detect_auth_mode(tmp_path) == AUTH_MODE_APIKEY
 
-    def test_legacy_config_auth_key(
+    def test_removed_legacy_config_auth_key_is_ignored(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        # Current Codex dropped preferred_auth_method and ignores it silently,
+        # so a stale copy left in a config must not name the login either.
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         (tmp_path / "config.toml").write_text('preferred_auth_method = "apikey"\n')
-        assert detect_auth_mode(tmp_path) == AUTH_MODE_APIKEY
+        assert detect_auth_mode(tmp_path) == AUTH_MODE_UNKNOWN
 
     def test_config_chatgpt_login_keeps_gate_active(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_budget_codex.py
+++ b/tests/test_budget_codex.py
@@ -170,6 +170,22 @@ class TestDetectAuthMode:
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
         assert detect_auth_mode(tmp_path) == AUTH_MODE_APIKEY
 
+    def test_codex_api_key_overrides_chatgpt_auth_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CODEX_API_KEY", "sk-test")
+        (tmp_path / "auth.json").write_text(json.dumps({"auth_mode": "chatgpt"}))
+        assert detect_auth_mode(tmp_path) == AUTH_MODE_APIKEY
+
+    def test_openai_api_key_loses_to_chatgpt_auth_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Codex keeps using the cached ChatGPT login here, so plan rate limits
+        # still apply and the gate has to stay active.
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        (tmp_path / "auth.json").write_text(json.dumps({"auth_mode": "chatgpt"}))
+        assert detect_auth_mode(tmp_path) == AUTH_MODE_CHATGPT
+
     def test_malformed_auth_file_falls_back(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_budget_policy.py
+++ b/tests/test_budget_policy.py
@@ -6,7 +6,16 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from mr_overkill.budget import budget_sufficient, codex_parse_window
+import pytest
+
+from mr_overkill.budget import (
+    FIVE_HOUR_WINDOW,
+    SEVEN_DAY_WINDOW,
+    budget_gate_disabled,
+    budget_sufficient,
+    codex_parse_window,
+    codex_window_kind,
+)
 from mr_overkill.budget.claude import (
     _load_cache,
     _save_cache,
@@ -113,6 +122,62 @@ class TestCodexParseWindow:
         pct, resets = codex_parse_window(window, 1000)
         assert pct == 30
         assert resets is None
+
+
+# ── codex_window_kind ───────────────────────────────────────────────
+
+
+class TestCodexWindowKind:
+    def test_five_hour_window(self) -> None:
+        assert codex_window_kind({"window_minutes": 300}) == FIVE_HOUR_WINDOW
+
+    def test_weekly_window(self) -> None:
+        assert codex_window_kind({"window_minutes": 10080}) == SEVEN_DAY_WINDOW
+
+    def test_daily_boundary_counts_as_short(self) -> None:
+        assert codex_window_kind({"window_minutes": 1440}) == FIVE_HOUR_WINDOW
+
+    def test_just_over_daily_counts_as_weekly(self) -> None:
+        assert codex_window_kind({"window_minutes": 1441}) == SEVEN_DAY_WINDOW
+
+    def test_string_minutes(self) -> None:
+        assert codex_window_kind({"window_minutes": "10080"}) == SEVEN_DAY_WINDOW
+
+    def test_missing_minutes_is_unclassified(self) -> None:
+        assert codex_window_kind({"used_percent": 50.0}) is None
+
+    def test_malformed_minutes_is_unclassified(self) -> None:
+        assert codex_window_kind({"window_minutes": "soon"}) is None
+
+    def test_non_positive_minutes_is_unclassified(self) -> None:
+        assert codex_window_kind({"window_minutes": 0}) is None
+
+    def test_empty_window(self) -> None:
+        assert codex_window_kind(None) is None
+        assert codex_window_kind({}) is None
+
+
+# ── budget_gate_disabled ────────────────────────────────────────────
+
+
+class TestBudgetGateDisabled:
+    def test_unset_is_enabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OVERKILL_SKIP_BUDGET", raising=False)
+        assert budget_gate_disabled() is False
+
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on", " on "])
+    def test_truthy_values(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ) -> None:
+        monkeypatch.setenv("OVERKILL_SKIP_BUDGET", value)
+        assert budget_gate_disabled() is True
+
+    @pytest.mark.parametrize("value", ["", "0", "false", "no"])
+    def test_falsy_values(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ) -> None:
+        monkeypatch.setenv("OVERKILL_SKIP_BUDGET", value)
+        assert budget_gate_disabled() is False
 
 
 # ── _sum_usage: rate-limit weights ───────────────────────────────

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,6 +62,31 @@ class TestLoadRcFile:
         assert result["REVIEWER_BACKEND"] == "claude"
         assert "INVALID_KEY" not in result
 
+    @patch("mr_overkill.cli.subprocess.run")
+    def test_parses_no_budget_gate(
+        self, mock_run: MagicMock, tmp_path: Path
+    ) -> None:
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout=str(tmp_path)
+        )
+        (tmp_path / ".overkill").mkdir()
+        rc = tmp_path / ".overkill" / ".overkillrc"
+        rc.write_text("NO_BUDGET_GATE=True\n")
+        assert _load_rc_file(".overkillrc")["NO_BUDGET_GATE"] == "true"
+
+    @patch("mr_overkill.cli.subprocess.run")
+    def test_rejects_non_boolean_no_budget_gate(
+        self, mock_run: MagicMock, tmp_path: Path
+    ) -> None:
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout=str(tmp_path)
+        )
+        (tmp_path / ".overkill").mkdir()
+        rc = tmp_path / ".overkill" / ".overkillrc"
+        rc.write_text("NO_BUDGET_GATE=yes\n")
+        with pytest.raises(SystemExit):
+            _load_rc_file(".overkillrc")
+
 
 class TestParseReviewLoopArgs:
     @patch("mr_overkill.cli._detect_pr_number", return_value=None)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -105,6 +105,54 @@ class TestParseReviewLoopArgs:
     @patch("mr_overkill.cli._detect_current_branch", return_value="feat/x")
     @patch("mr_overkill.cli._load_rc_file", return_value={})
     @patch("mr_overkill.cli.subprocess.run")
+    def test_budget_gate_enabled_by_default(
+        self,
+        mock_run: MagicMock,
+        mock_rc: MagicMock,
+        mock_branch: MagicMock,
+        mock_pr: MagicMock,
+    ) -> None:
+        mock_run.return_value = MagicMock(returncode=0, stdout="/tmp/repo")
+        config = parse_review_loop_args(["-n", "1"])
+        assert config.skip_budget_gate is False
+
+    @patch("mr_overkill.cli._detect_pr_number", return_value=None)
+    @patch("mr_overkill.cli._detect_current_branch", return_value="feat/x")
+    @patch("mr_overkill.cli._load_rc_file", return_value={})
+    @patch("mr_overkill.cli.subprocess.run")
+    def test_no_budget_gate_flag(
+        self,
+        mock_run: MagicMock,
+        mock_rc: MagicMock,
+        mock_branch: MagicMock,
+        mock_pr: MagicMock,
+    ) -> None:
+        mock_run.return_value = MagicMock(returncode=0, stdout="/tmp/repo")
+        config = parse_review_loop_args(["-n", "1", "--no-budget-gate"])
+        assert config.skip_budget_gate is True
+
+    @patch("mr_overkill.cli._detect_pr_number", return_value=None)
+    @patch("mr_overkill.cli._detect_current_branch", return_value="feat/x")
+    @patch(
+        "mr_overkill.cli._load_rc_file",
+        return_value={"NO_BUDGET_GATE": "true"},
+    )
+    @patch("mr_overkill.cli.subprocess.run")
+    def test_no_budget_gate_from_rc(
+        self,
+        mock_run: MagicMock,
+        mock_rc: MagicMock,
+        mock_branch: MagicMock,
+        mock_pr: MagicMock,
+    ) -> None:
+        mock_run.return_value = MagicMock(returncode=0, stdout="/tmp/repo")
+        config = parse_review_loop_args(["-n", "1"])
+        assert config.skip_budget_gate is True
+
+    @patch("mr_overkill.cli._detect_pr_number", return_value=None)
+    @patch("mr_overkill.cli._detect_current_branch", return_value="feat/x")
+    @patch("mr_overkill.cli._load_rc_file", return_value={})
+    @patch("mr_overkill.cli.subprocess.run")
     def test_no_self_review(
         self,
         mock_run: MagicMock,
@@ -430,6 +478,7 @@ class TestParseRefactorSuggestArgs:
         assert config.max_loop == 1
         assert extra.create_pr is False
         assert extra.with_review is False
+        assert config.skip_budget_gate is False
         # refactor-suggest does not push a trigger commit, so iteration
         # commits must trigger CI directly — never inherit "last-only".
         assert config.ci_trigger_mode == "every"
@@ -452,6 +501,21 @@ class TestParseRefactorSuggestArgs:
         assert config.scope == "module"
         assert config.max_loop == 3
         assert config.target_branch == "main"
+
+    @patch("mr_overkill.cli._detect_current_branch", return_value="feat/x")
+    @patch("mr_overkill.cli._load_rc_file", return_value={})
+    @patch("mr_overkill.cli.subprocess.run")
+    def test_no_budget_gate_flag(
+        self,
+        mock_run: MagicMock,
+        mock_rc: MagicMock,
+        mock_branch: MagicMock,
+    ) -> None:
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="/tmp/repo"
+        )
+        config, _extra = parse_refactor_suggest_args(["--no-budget-gate"])
+        assert config.skip_budget_gate is True
 
     @patch("mr_overkill.cli._detect_current_branch", return_value="feat/x")
     @patch("mr_overkill.cli._load_rc_file", return_value={})

--- a/tests/test_refactor_suggest.py
+++ b/tests/test_refactor_suggest.py
@@ -58,6 +58,14 @@ class TestResolveAutoScope:
         mock_bs.return_value = _budget(95, 95)
         assert resolve_auto_scope(["claude"]) is None
 
+    @patch("mr_overkill.refactor_suggest._get_budget_status")
+    def test_skip_gate_resolves_module_when_exhausted(
+        self, mock_bs: MagicMock
+    ) -> None:
+        mock_bs.return_value = _budget(100, 100)
+        assert resolve_auto_scope(["claude"], skip_gate=True) == "module"
+        mock_bs.assert_not_called()
+
 
 # ── _get_budget_status ──────────────────────────────────────────────
 
@@ -131,6 +139,33 @@ class TestCreateDraftPr:
 
 
 class TestRun:
+    @patch("mr_overkill.refactor_suggest.git_all_dirty", return_value=[])
+    @patch("mr_overkill.refactor_suggest.review_fix_loop")
+    @patch("mr_overkill.refactor_suggest.resolve_auto_scope")
+    @patch("mr_overkill.refactor_suggest.subprocess.run")
+    def test_auto_scope_receives_skip_budget_gate(
+        self,
+        mock_run: MagicMock,
+        mock_scope: MagicMock,
+        mock_loop: MagicMock,
+        _mock_dirty: MagicMock,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="src/a.py\n"
+        )
+        mock_scope.return_value = "module"
+        mock_loop.return_value = LoopResult(
+            final_status=FinalStatus.ALL_CLEAR,
+            iterations_run=1,
+        )
+        config = make_loop_config(
+            current_branch="refactor/module-20260301",
+            skip_budget_gate=True,
+        )
+        assert run(config, "auto") == 0
+        assert mock_scope.call_args.kwargs["skip_gate"] is True
+
     @patch("mr_overkill.refactor_suggest.git_all_dirty", return_value=[])
     @patch("mr_overkill.refactor_suggest.review_fix_loop")
     @patch("mr_overkill.refactor_suggest.git_all_dirty", return_value=[])


### PR DESCRIPTION
## Problem

After switching Codex to API-key auth, `overkill review-loop` blocked immediately:

```
[WARNING] mr_overkill.budget: Budget check failed: 90% used (threshold for 'micro' is <90%)
[INFO] mr_overkill.retry: Budget insufficient for codex (scope: micro). Waiting for reset...
```

The 90% came from a `token_count` event written under the *previous* ChatGPT login. Since nothing new is ever appended in API-key mode, `wait_for_budget()` polled the same stale file until it timed out.

Two independent defects:

1. **Auth mode was never consulted.** API-key billing has no plan rate-limit windows, so any session-log data is irrelevant to it.
2. **Windows were mapped positionally.** The offending payload was `primary: {used_percent: 90.0, window_minutes: 10080, resets_at: <5 days out>}` — the *weekly* window, checked against the 5-hour threshold. On some plans Codex sends the weekly limit as `primary`.

## Changes

- `budget/codex.py`: `detect_auth_mode()` reads `$CODEX_HOME/auth.json` (falling back to `OPENAI_API_KEY`, then to `unknown`, which keeps the gate on). Under `apikey` the checker returns an empty `BudgetStatus(mode="apikey")` and `codex_budget_sufficient()` short-circuits to `True` — the same treatment `budget/gemini.py` already gives API-key billing.
- `budget/__init__.py`: `codex_window_kind()` classifies a window by its declared `window_minutes` (≤ 1 day → short window, longer → weekly). `_map_windows()` uses positional assignment only as a fallback for payloads without `window_minutes`, and keeps the higher usage when two windows land on the same kind.
- **Escape hatch**: `--no-budget-gate` on `review-loop` and `refactor-suggest`, `NO_BUDGET_GATE` in the rc files, `OVERKILL_SKIP_BUDGET=1` in the environment. Budget data is a local estimate; a wrong estimate should not be a dead end.
- `check-budget` reports API-key mode instead of printing empty percentages.
- Tests are isolated from `OPENAI_API_KEY` / `CODEX_HOME` / `OVERKILL_SKIP_BUDGET` so auth detection does not vary by shell.

## Verification

- 348 tests pass; ruff and mypy clean.
- On the reporting machine (`auth_mode: apikey`, stale 90% weekly event): `overkill check-budget` now shows `Mode: apikey` with micro/module GO, where it previously reported NOGO.
- Defect 2 is covered independently: with `auth_mode: chatgpt` and the same payload, 90% now lands in `seven_day_used_pct` — micro GO, module NOGO, which is the intended policy.