### PR TITLE
refactor(budget): detect the Codex login from disk alone

### DIFF
--- a/src/mr_overkill/budget/codex.py
+++ b/src/mr_overkill/budget/codex.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import subprocess
 import tomllib
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -48,15 +47,6 @@ _AUTH_MODE_ALIASES = {
     "chatgpt": AUTH_MODE_CHATGPT,
 }
 
-# Prefixes of ``codex login status`` output, mapped to the canonical mode.
-# Anything else (access tokens, "Not logged in") stays ``unknown`` so the
-# plan-based gate keeps running.
-_LOGIN_STATUS_MODES = (
-    ("logged in using an api key", AUTH_MODE_APIKEY),
-    ("logged in using amazon bedrock api key", AUTH_MODE_APIKEY),
-    ("logged in using chatgpt", AUTH_MODE_CHATGPT),
-)
-
 
 def codex_home() -> Path:
     """Return the Codex config directory (``$CODEX_HOME`` or ``~/.codex``)."""
@@ -87,55 +77,21 @@ def _config_auth_mode(home: Path) -> str | None:
     return None
 
 
-def _login_status_auth_mode(home: Path) -> str | None:
-    """Return the mode reported by ``codex login status``, or ``None``.
-
-    This is the only way to read a keyring-backed login: the credential never
-    touches disk, so neither auth.json nor config.toml has to mention it.
-    ``None`` means the probe told us nothing — Codex is missing from PATH, it
-    failed, or it named a login we deliberately do not treat as API-key auth.
-
-    A keyring-backed login is exactly the setup that can make Codex block on an
-    OS keychain prompt, and this runs on the pre-flight path re-entered by every
-    budget poll, so the probe is bounded rather than allowed to stall the loop.
-    """
-    try:
-        result = subprocess.run(
-            ["codex", "login", "status"],
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=5,
-            env={**os.environ, "CODEX_HOME": str(home)},
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-
-    if result.returncode != 0:
-        return None
-
-    # Codex prints the status line on stderr; stdout is checked too so a later
-    # version moving it there keeps working.  Every line is examined because a
-    # warning or banner ahead of the status line must not hide it.
-    for stream in (result.stderr, result.stdout):
-        for line in stream.splitlines():
-            status = line.strip().lower()
-            for prefix, mode in _LOGIN_STATUS_MODES:
-                if status.startswith(prefix):
-                    return mode
-
-    return None
-
-
 def detect_auth_mode(home: Path | None = None) -> str:
     """Detect how the Codex CLI authenticates.
 
     ``CODEX_API_KEY`` wins outright: Codex sends it even when ``auth.json``
     holds a ChatGPT login.  Otherwise ``auth.json`` is authoritative, since it
     records the mode chosen by the last ``codex login``.  Falls back to the
-    login method declared in ``config.toml``, then to what ``codex login
-    status`` reports, then to ``unknown`` (which keeps the plan-based budget
-    gate active).
+    login method declared in ``config.toml``, then to ``unknown``.
+
+    Only reads what is already on disk.  Logins this cannot name — credentials
+    kept in the OS keyring, Bedrock, access tokens — come back ``unknown``,
+    which leaves the plan gate active.  That is deliberate rather than a gap:
+    a login with no plan windows reports no usage either, so the gate finds no
+    data and lets the run through anyway.  The only setup it actually blocks is
+    a switch away from a ChatGPT plan whose session logs are still unexpired,
+    and ``--no-budget-gate`` covers that.
     """
     if home is None:
         home = codex_home()
@@ -165,18 +121,13 @@ def detect_auth_mode(home: Path | None = None) -> str:
 
     # auth.json can be missing entirely when Codex keeps credentials in the OS
     # keyring (``cli_auth_credentials_store``); config.toml may still declare
-    # the login method, so consult it before giving up on the file layout.
+    # the login method, so consult it before giving up.  An ambient
+    # OPENAI_API_KEY is deliberately not consulted: Codex does not authenticate
+    # with it, so a key left in the environment for other tools must not switch
+    # the gate off.
     config_mode = _config_auth_mode(home)
     if config_mode is not None:
         return config_mode
-
-    # Nothing on disk names the login, which is normal for a keyring-backed
-    # one.  Ask Codex itself as a last resort.  An ambient OPENAI_API_KEY is
-    # deliberately not consulted: Codex does not authenticate with it, so a key
-    # left in the environment for other tools must not switch the gate off.
-    status_mode = _login_status_auth_mode(home)
-    if status_mode is not None:
-        return status_mode
 
     return AUTH_MODE_UNKNOWN
 

--- a/tests/test_budget_codex.py
+++ b/tests/test_budget_codex.py
@@ -3,13 +3,11 @@
 from __future__ import annotations
 
 import json
-import subprocess
 from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
 
-from mr_overkill.budget import codex as codex_budget
 from mr_overkill.budget.codex import (
     AUTH_MODE_APIKEY,
     AUTH_MODE_CHATGPT,
@@ -21,20 +19,6 @@ from mr_overkill.budget.codex import (
     find_latest_token_count,
 )
 from mr_overkill.models import BudgetScope
-
-# Captured before any test patches it, so the probe's own tests can restore it.
-_REAL_LOGIN_STATUS_PROBE = codex_budget._login_status_auth_mode
-
-
-@pytest.fixture(autouse=True)
-def _no_login_status_probe(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Keep ``codex login status`` out of the tests that predate the probe.
-
-    Detection falls through to it whenever nothing on disk names the login, so
-    without this every such test would spawn the real CLI.  Tests that cover
-    the probe restore it explicitly.
-    """
-    monkeypatch.setattr(codex_budget, "_login_status_auth_mode", lambda home: None)
 
 
 def _write_session(
@@ -281,157 +265,6 @@ class TestDetectAuthMode:
         assert codex_home() == Path("/custom/codex")
 
 
-# ── keyring logins, read back from ``codex login status`` ────────────
-
-
-def _stub_login_status(
-    monkeypatch: pytest.MonkeyPatch,
-    status: str,
-    returncode: int = 0,
-    stream: str = "stderr",
-) -> None:
-    """Make ``codex login status`` report ``status`` without running Codex.
-
-    Real Codex prints the status line on stderr, so that is the default.
-    """
-
-    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-        assert cmd == ["codex", "login", "status"]
-        return subprocess.CompletedProcess(
-            cmd,
-            returncode,
-            status if stream == "stdout" else "",
-            status if stream == "stderr" else "",
-        )
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-
-
-class TestLoginStatusProbe:
-    @pytest.fixture(autouse=True)
-    def _use_real_probe(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        # Put the real probe back: these tests are about the probe itself, and
-        # stub ``subprocess.run`` instead of the function under test.
-        monkeypatch.setattr(
-            codex_budget, "_login_status_auth_mode", _REAL_LOGIN_STATUS_PROBE
-        )
-
-    @pytest.mark.parametrize("stream", ["stderr", "stdout"])
-    @pytest.mark.parametrize(
-        ("status", "expected"),
-        [
-            ("Logged in using an API key - sk-proj-***abcde", AUTH_MODE_APIKEY),
-            ("Logged in using Amazon Bedrock API key", AUTH_MODE_APIKEY),
-            ("Logged in using ChatGPT", AUTH_MODE_CHATGPT),
-        ],
-    )
-    def test_reports_the_active_login(
-        self,
-        tmp_path: Path,
-        monkeypatch: pytest.MonkeyPatch,
-        status: str,
-        expected: str,
-        stream: str,
-    ) -> None:
-        # A keyring-backed login leaves nothing on disk to read.
-        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-        _stub_login_status(monkeypatch, status, stream=stream)
-        assert detect_auth_mode(tmp_path) == expected
-
-    def test_a_warning_ahead_of_the_status_line_is_skipped(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        # Codex may print a warning first; the status line still has to be read.
-        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-        _stub_login_status(
-            monkeypatch,
-            "warning: config.toml: unknown key `foo`\n"
-            "Logged in using an API key - sk-proj-***abcde",
-        )
-        assert detect_auth_mode(tmp_path) == AUTH_MODE_APIKEY
-
-    def test_chatgpt_login_beats_an_ambient_openai_api_key(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        # The gate must not be switched off by the environment when Codex
-        # itself says the keyring holds a ChatGPT login.
-        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
-        _stub_login_status(monkeypatch, "Logged in using ChatGPT")
-        assert detect_auth_mode(tmp_path) == AUTH_MODE_CHATGPT
-
-    @pytest.mark.parametrize(
-        ("status", "returncode"),
-        [
-            ("Not logged in", 1),
-            ("Logged in using access token", 0),
-            ("", 0),
-        ],
-    )
-    def test_unreadable_logins_keep_the_gate_active(
-        self,
-        tmp_path: Path,
-        monkeypatch: pytest.MonkeyPatch,
-        status: str,
-        returncode: int,
-    ) -> None:
-        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-        _stub_login_status(monkeypatch, status, returncode)
-        assert detect_auth_mode(tmp_path) == AUTH_MODE_UNKNOWN
-
-    def test_missing_codex_binary_keeps_the_gate_active(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-
-        def raise_oserror(cmd: list[str], **kwargs: object) -> None:
-            raise OSError("codex not found")
-
-        monkeypatch.setattr(subprocess, "run", raise_oserror)
-        assert detect_auth_mode(tmp_path) == AUTH_MODE_UNKNOWN
-
-    def test_a_hung_probe_keeps_the_gate_active(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        # A keychain prompt on a non-interactive run would otherwise block the
-        # budget poll forever, so the probe must be bounded and give up quietly.
-        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-
-        def raise_timeout(cmd: list[str], **kwargs: object) -> None:
-            assert kwargs["timeout"]
-            raise subprocess.TimeoutExpired(cmd, 5)
-
-        monkeypatch.setattr(subprocess, "run", raise_timeout)
-        assert detect_auth_mode(tmp_path) == AUTH_MODE_UNKNOWN
-
-    def test_config_login_method_wins_over_the_probe(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        # config.toml forces the login method, so there is nothing to ask.
-        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-        (tmp_path / "config.toml").write_text('forced_login_method = "chatgpt"\n')
-        _stub_login_status(monkeypatch, "Logged in using an API key - sk-x")
-        assert detect_auth_mode(tmp_path) == AUTH_MODE_CHATGPT
-
-    def test_probe_runs_against_the_given_codex_home(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-        seen: dict[str, str] = {}
-
-        def fake_run(
-            cmd: list[str], **kwargs: object
-        ) -> subprocess.CompletedProcess[str]:
-            env = kwargs["env"]
-            assert isinstance(env, dict)
-            seen.update(env)
-            return subprocess.CompletedProcess(cmd, 0, "", "Logged in using ChatGPT")
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
-        detect_auth_mode(tmp_path)
-
-        assert seen["CODEX_HOME"] == str(tmp_path)
-
-
 class TestApiKeyMode:
     def test_ignores_stale_session_logs(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -457,6 +290,38 @@ class TestApiKeyMode:
         assert status.mode == AUTH_MODE_APIKEY
         assert status.five_hour_used_pct is None
         assert status.seven_day_used_pct is None
+        assert codex_budget_sufficient(BudgetScope.MICRO, status) is True
+        assert codex_budget_sufficient(BudgetScope.MODULE, status) is True
+
+    @pytest.mark.parametrize(
+        "rate_limits",
+        [{}, {"primary": None, "secondary": None}],
+        ids=["no_windows", "null_windows"],
+    )
+    def test_unnamed_login_without_plan_windows_still_runs(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        rate_limits: dict[str, object],
+    ) -> None:
+        """Detection does not have to name every login for the gate to be right.
+
+        Bedrock, keyring-stored credentials and access tokens all land on
+        ``unknown``, which keeps the gate active — but a login billed per token
+        reports no rate-limit windows either, so there is nothing for the gate
+        to fail on.  This is why naming those logins is not worth the code.
+        """
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        (tmp_path / "auth.json").write_text(
+            json.dumps({"auth_mode": "bedrockApiKey"})
+        )
+        sessions = tmp_path / "sessions"
+        _write_session(sessions, rate_limits)
+
+        assert detect_auth_mode(tmp_path) != AUTH_MODE_APIKEY
+        status = check_token_budget(sessions)
+
+        assert status.five_hour_used_pct is None
         assert codex_budget_sufficient(BudgetScope.MICRO, status) is True
         assert codex_budget_sufficient(BudgetScope.MODULE, status) is True
 


### PR DESCRIPTION
Removes the `codex login status` subprocess probe and the Bedrock spelling table from auth detection.

## Why

Both were added by review iterations on the 0.8.1 cycle, chasing logins that never touch disk (OS keyring, Bedrock). Neither earns its keep:

- The probe forks a process on the **pre-flight path that every budget poll re-enters**. A keyring-backed login is exactly the setup where Codex can block on an OS keychain prompt — which is why the probe needed a 5s timeout of its own (`f5422e8`) to stop stalling the loop.
- A login billed per token (Bedrock, API key) **reports no rate-limit windows at all**, so it produces no usage data for the gate to fail on. Falling through to `unknown` keeps the gate nominally active but lets the run proceed anyway.

The only setup the probe genuinely rescued is a switch away from a ChatGPT plan whose session logs have not expired yet — and `--no-budget-gate` / `OVERKILL_SKIP_BUDGET=1` already covers that.

## What changed

- Deleted `_login_status_auth_mode()`, `_LOGIN_STATUS_MODES`, and the `subprocess` import.
- Dropped the Bedrock aliases. `bedrockApiKey` is a real Codex `auth_mode` value, but it now falls through to `unknown` by design.
- `detect_auth_mode()` reads `CODEX_API_KEY` → `auth.json` → `config.toml` (`forced_login_method`) → `unknown`.
- Added `test_unnamed_login_without_plan_windows_still_runs`, which pins the fall-through: an unnamed login with no rate-limit windows still gets a GO. The docstring records why those logins are deliberately left unnamed, so the next review pass has the reasoning in front of it.

Net: **-184 lines** (75 in `codex.py`, the rest in tests).

## Compatibility

None of the removed code has shipped. `v0.8.0` has no `detect_auth_mode()` at all — the probe was added on this release cycle, so no released version has ever probed the CLI.

## Verification

- 363 tests pass; ruff and mypy clean.
- `overkill check-budget` on an `auth_mode: apikey` machine still reports `Mode: apikey` with no plan limits.