### PR TITLE
fix(budget): keep a corrupt Codex credential file from killing the review loop

### DIFF
--- a/src/mr_overkill/budget/codex.py
+++ b/src/mr_overkill/budget/codex.py
@@ -64,7 +64,9 @@ def _config_auth_mode(home: Path) -> str | None:
     try:
         with (home / "config.toml").open("rb") as handle:
             config = tomllib.load(handle)
-    except (OSError, tomllib.TOMLDecodeError):
+    except (OSError, ValueError):
+        # ValueError covers both TOMLDecodeError and the UnicodeDecodeError
+        # tomllib raises when it decodes the bytes itself.
         return None
 
     for key in _CONFIG_AUTH_KEYS:
@@ -103,7 +105,10 @@ def detect_auth_mode(home: Path | None = None) -> str:
 
     try:
         auth = json.loads((home / "auth.json").read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except (OSError, ValueError):
+        # ValueError covers both JSONDecodeError and the UnicodeDecodeError a
+        # non-UTF-8 auth.json raises: an unreadable file means "mode unknown",
+        # not a crashed review loop.
         auth = None
 
     if isinstance(auth, dict):

--- a/tests/test_budget_codex.py
+++ b/tests/test_budget_codex.py
@@ -260,6 +260,20 @@ class TestDetectAuthMode:
         (tmp_path / "auth.json").write_text("{not json")
         assert detect_auth_mode(tmp_path) == AUTH_MODE_UNKNOWN
 
+    def test_non_utf8_config_falls_back(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        (tmp_path / "config.toml").write_bytes(b'forced_login_method = "\xff api"')
+        assert detect_auth_mode(tmp_path) == AUTH_MODE_UNKNOWN
+
+    def test_non_utf8_auth_file_falls_back(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        (tmp_path / "auth.json").write_bytes(b'{"auth_mode": "\xffapikey"}')
+        assert detect_auth_mode(tmp_path) == AUTH_MODE_UNKNOWN
+
     def test_codex_home_respects_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("CODEX_HOME", "/custom/codex")
         assert codex_home() == Path("/custom/codex")


### PR DESCRIPTION
Cherry-pick of `298afa2` from `release/0.8.2`, so the fix lands in `develop` before the release PR merges into `main` (CLAUDE.md release process, step 2).

## Problem

`detect_auth_mode()` and `_config_auth_mode()` caught the parse errors of `json` and `tomllib`, but not the `UnicodeDecodeError` that `Path.read_text` and tomllib's own byte decoding raise on a non-UTF-8 `auth.json` or `config.toml`. Nothing upstream handles it, so a corrupt credential file aborted the whole review loop with a traceback — where a *malformed* file already falls back to `unknown`.

## Fix

Both `except` clauses widen to `ValueError`, which covers the decode error alongside the parse errors they already caught (`JSONDecodeError`, `TOMLDecodeError`, and `UnicodeDecodeError` are all `ValueError` subclasses).

## Verification

- Found by the review loop on the 0.8.2 release PR (#153); that run went `all_clear` on both the Claude and Codex passes after this fix.
- 367 tests pass; ruff and mypy clean.