### PR TITLE
fix(self-review): restore the sub-loop that a rejected git flag had disabled

### DIFF
--- a/src/mr_overkill/self_review.py
+++ b/src/mr_overkill/self_review.py
@@ -278,14 +278,22 @@ def _generate_diff(
         check=False,
     )
 
+    # Paths go in argv after ``--``: unlike add/reset, ``git diff`` has no
+    # --pathspec-from-file option and exits 129 on it, which would silently
+    # write an empty diff and skip the self-review for every iteration.
     result = subprocess.run(
-        ["git", "diff", "HEAD", "--pathspec-from-file=-"],
-        input=pathspec,
+        ["git", "diff", "HEAD", "--", *changed_files],
         cwd=cwd,
         capture_output=True,
         text=True,
         check=False,
     )
+    if result.returncode != 0:
+        logger.warning(
+            "git diff failed (exit %d): %s",
+            result.returncode,
+            result.stderr.strip(),
+        )
     output.write_text(result.stdout, encoding="utf-8")
 
     # Undo intent-to-add

--- a/tests/test_self_review.py
+++ b/tests/test_self_review.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -10,6 +11,7 @@ from mr_overkill.models import WorktreeSnapshot
 from mr_overkill.self_review import (
     _FIX_NITS_GUIDELINES,
     _compute_fingerprint,
+    _generate_diff,
     self_review_subloop,
 )
 
@@ -449,3 +451,61 @@ class TestFixNitsGuidelines:
 
         assert len(captured_prompt) == 1
         assert "Fix nits" not in captured_prompt[0]
+
+
+class TestGenerateDiff:
+    """Exercise _generate_diff against a real git repo.
+
+    Every other test in this module patches _generate_diff out, so the real
+    command line was never run: it passed --pathspec-from-file to ``git diff``,
+    which rejects the option, and the discarded stderr turned that into an
+    empty diff that skipped the self-review on every iteration.
+    """
+
+    def test_modified_tracked_file(self, tmp_git_repo: Path) -> None:
+        (tmp_git_repo / "README.md").write_text("# test\nsecond line\n")
+        output = tmp_git_repo / "out.diff"
+
+        _generate_diff(["README.md"], output, tmp_git_repo)
+
+        diff = output.read_text()
+        assert "+second line" in diff
+        assert "a/README.md" in diff
+
+    def test_untracked_file_included(self, tmp_git_repo: Path) -> None:
+        (tmp_git_repo / "new.py").write_text("print('hi')\n")
+        output = tmp_git_repo / "out.diff"
+
+        _generate_diff(["new.py"], output, tmp_git_repo)
+
+        assert "+print('hi')" in output.read_text()
+
+    def test_intent_to_add_is_undone(self, tmp_git_repo: Path) -> None:
+        """The untracked file must be left unstaged for the later commit step."""
+        (tmp_git_repo / "new.py").write_text("print('hi')\n")
+
+        _generate_diff(["new.py"], tmp_git_repo / "out.diff", tmp_git_repo)
+
+        staged = subprocess.run(
+            ["git", "diff", "--cached", "--name-only"],
+            cwd=tmp_git_repo,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert staged.stdout.strip() == ""
+
+    def test_path_with_spaces(self, tmp_git_repo: Path) -> None:
+        (tmp_git_repo / "my file.txt").write_text("content\n")
+        output = tmp_git_repo / "out.diff"
+
+        _generate_diff(["my file.txt"], output, tmp_git_repo)
+
+        assert "+content" in output.read_text()
+
+    def test_no_changed_files_writes_empty(self, tmp_git_repo: Path) -> None:
+        output = tmp_git_repo / "out.diff"
+
+        _generate_diff([], output, tmp_git_repo)
+
+        assert output.read_text() == ""


### PR DESCRIPTION
## Problem

The self-review sub-loop has never run. `_generate_diff` passed `--pathspec-from-file` to `git diff`:

```
$ git diff HEAD --pathspec-from-file=- < paths.txt
usage: git diff [<options>] ...
EXIT=129
```

Unlike `add`/`commit`/`reset`, `git diff` has no such option. With `check=False` and stderr discarded, the usage error was written out as an **empty diff file**, so the `size == 0` guard broke out on the first sub-iteration of every run.

Field evidence from a repo using overkill — ten iterations across several days:

```
diff-1-1.diff … 0    diff-6-1.diff  … 0
diff-2-1.diff … 0    diff-7-1.diff  … 0
...                  diff-10-1.diff … 0
```

All 0 bytes, and every filename ends in `-1` — sub-iteration 2 was never reached, despite `max_subloop` defaulting to 4.

## Impact

- Fixes were committed and pushed with nothing verifying they actually addressed the findings.
- `--fix-nits` was a complete no-op: `_FIX_NITS_GUIDELINES` is injected below the `break`, so its "any finding remaining means `patch is incorrect`" rule never applied.

## Fix

Pass paths in argv after `--`, and log a failing `git diff` so a future error of this kind cannot pass for "no changes". The surrounding `intent-to-add` / `reset` calls keep `--pathspec-from-file` — those subcommands do support it.

## Why tests missed it

Every existing test patches `_generate_diff` itself, so the real command line was never executed. The new `TestGenerateDiff` runs it against a real git repo; three of its five cases fail on the previous implementation and pass on this one.

`372 passed`, ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)