### PR TITLE
feat(review-loop): review an already-merged commit to improve it

### DIFF
--- a/.overkillrc.example
+++ b/.overkillrc.example
@@ -17,6 +17,9 @@
 # Enable auto-commit of fixes (default: true)
 # AUTO_COMMIT=true
 
+# Push the review/* branch created by --commit (default: false — stays local)
+# COMMIT_SCOPE_PUSH=false
+
 # CI trigger policy for iteration commits (default: last-only)
 #   last-only — append "[skip ci]" to each iteration commit; push a single
 #               empty "chore: trigger CI" commit only when the loop ends

--- a/README.md
+++ b/README.md
@@ -94,14 +94,25 @@ overkill refactor-suggest -n 1 --dry-run
 overkill review-loop [OPTIONS]
 
 Options:
-  -t, --target <branch>    Target branch to diff against (default: develop)
+  -t, --target <rev>       Target to diff against (default: develop). Accepts any
+                           git revision, not just a branch name: a SHA, a tag, or
+                           HEAD~5 all work, so you can review "everything since
+                           commit X" without opening a PR.
+  --commit <rev>           Review an already-merged commit instead of the branch
+                           diff. Creates a review/<sha>-<ts> branch off HEAD and
+                           applies fixes there; no PR is created. <rev> is a single
+                           commit — ranges are not supported. Excludes -t.
+  --push                   Push the auto-created review branch (default: local only)
   -n, --max-loop <N>       Maximum review-fix iterations (required, unless --resume)
   --max-subloop <N>        Maximum self-review sub-iterations per fix (default: 4)
   --no-self-review         Disable self-review (equivalent to --max-subloop 0)
   --dry-run                Run review only, do not fix
   --no-auto-commit         Fix but do not commit/push (single iteration)
   --resume                 Resume from a previously interrupted run (reuses existing logs)
-  --reviewer-backend <be>  Reviewer backend: claude|codex (default: codex)
+  --fix-nits               Also flag nits and style issues during self-review
+  --context <text>         Additional context for the reviewer (design intent,
+                           constraints)
+  --reviewer-backend <be>  Reviewer backend: claude|codex|gemini (default: codex)
   --ci-trigger-mode <m>    CI trigger policy: every|last-only|none (default: last-only).
                            'last-only' tags each iteration commit with [skip ci]
                            and pushes a single empty trigger commit on PASS —
@@ -119,7 +130,42 @@ Examples:
   overkill review-loop --resume              # resume an interrupted run
   overkill review-loop -n 2 --reviewer-backend claude  # use Claude as reviewer
   overkill review-loop -n 10 --ci-trigger-mode last-only  # CI fires once on PASS
+
+  # Review only what landed after a given commit, before opening a PR
+  overkill review-loop -t abc123 -n 3
+  overkill review-loop -t "$(git merge-base origin/develop HEAD)" -n 3
+
+  # Improve a commit that is already merged
+  overkill review-loop --commit abc123 -n 1 --dry-run   # report only, no branch
+  overkill review-loop --commit abc123 -n 3             # fix on a review/* branch
 ```
+
+### Reviewing an already-merged commit
+
+`--commit` exists for the case the branch diff cannot express: a change that
+already landed, which you now want to improve.
+
+1. The commit's diff is written to `.overkill/logs/scope.diff`. It is computed
+   against the commit's **first parent**, so merge commits produce a real patch
+   — `git show` prints nothing for those.
+2. A `review/<sha>-<timestamp>` branch is created off your current HEAD and the
+   fixes are committed there. The branch stays local unless you pass `--push`,
+   and no PR is created or commented on.
+3. The reviewer treats `scope.diff` as *scope only*. Since other commits may
+   have landed since, it must confirm each finding against the file's current
+   contents and cite current line numbers.
+
+Run it from a clean, up-to-date checkout of the branch the commit lives on:
+
+```bash
+git switch main && git pull
+overkill review-loop --commit abc123 -n 3
+```
+
+**After upgrading, re-run `overkill init`** in each repo — `--commit` needs the
+`${REVIEW_SCOPE_NOTE}` marker that the refreshed review prompts carry, and the
+run aborts with an explanatory error if it is missing. Note that `init`
+overwrites `.overkill/prompts/active/`, so back up any customised prompts first.
 
 ## Usage: overkill refactor-suggest
 
@@ -141,7 +187,7 @@ Options:
   --resume                 Resume from a previously interrupted run (reuses existing logs)
   --with-review            Run review-loop after PR creation (default: 4 iterations)
   --with-review-loops <N>  Set review-loop iteration count (implies --with-review)
-  --reviewer-backend <be>  Reviewer backend: claude|codex (default: codex)
+  --reviewer-backend <be>  Reviewer backend: claude|codex|gemini (default: codex)
   --diagnostic-log         Save full Claude event stream to sidecar files
   --no-budget-gate         Skip token-budget checks and run regardless
                            (same as OVERKILL_SKIP_BUDGET=1)

--- a/prompts/active/claude-review.prompt.md
+++ b/prompts/active/claude-review.prompt.md
@@ -1,5 +1,5 @@
 You are a code reviewer analyzing a proposed change.
-
+${REVIEW_SCOPE_NOTE}
 ## Context
 
 - **Current branch**: ${CURRENT_BRANCH}

--- a/prompts/active/codex-review.prompt.md
+++ b/prompts/active/codex-review.prompt.md
@@ -1,5 +1,5 @@
 You are a code reviewer analyzing a proposed change.
-
+${REVIEW_SCOPE_NOTE}
 ## Context
 
 - **Current branch**: ${CURRENT_BRANCH}

--- a/prompts/active/gemini-review.prompt.md
+++ b/prompts/active/gemini-review.prompt.md
@@ -1,5 +1,5 @@
 You are a code reviewer analyzing a proposed change.
-
+${REVIEW_SCOPE_NOTE}
 ## Context
 
 - **Current branch**: ${CURRENT_BRANCH}

--- a/src/mr_overkill/agents.py
+++ b/src/mr_overkill/agents.py
@@ -16,6 +16,7 @@ from abc import ABC, abstractmethod
 from importlib.resources import as_file, files
 from pathlib import Path
 
+from mr_overkill import commit_scope
 from mr_overkill.budget import SKIP_BUDGET_ENV_VAR, budget_gate_disabled
 from mr_overkill.budget.claude import claude_budget_sufficient
 from mr_overkill.budget.codex import codex_budget_sufficient
@@ -45,6 +46,119 @@ def _format_reviewer_context(raw: str) -> str:
     if not raw:
         return ""
     return f"## Author Context\n\n{raw}"
+
+
+_SCOPE_NOTE_MARKER = "${REVIEW_SCOPE_NOTE}"
+
+
+def _format_review_scope(config: LoopConfig, iteration: int) -> str:
+    """Build the commit-scope override block, or "" in normal mode.
+
+    Empty-string-means-no-section, like ``EXTRA_REVIEW_GUIDELINES`` in the
+    self-review prompt.  Note ``string.Template`` does not substitute
+    recursively, so every value here is interpolated in Python.
+    """
+    sha = config.scope_commit
+    if not sha:
+        return ""
+
+    diff_path = config.scope_diff_file
+    ancestry = ""
+    if not commit_scope.is_ancestor_of_head(sha):
+        ancestry = (
+            f"\n> WARNING: `{sha[:7]}` is **not an ancestor of HEAD**. Much of the "
+            "code it touched may not exist in the working tree at all. Report only "
+            "defects you can locate in a file that exists right now.\n"
+        )
+
+    if iteration <= 1:
+        fixes = (
+            "None yet — this is the first pass. The `git diff` command in the "
+            "Instructions section will print **nothing** on this iteration. That is "
+            "expected, it is not an error, and it is **not** the change under review."
+        )
+    else:
+        fixes = (
+            f"This is iteration {iteration}. Earlier iterations already produced fix "
+            "commits on this branch, and the `git diff` command in the Instructions "
+            "section prints **those fixes** — not the change under review. Use it to "
+            "(a) confirm which of your earlier findings are now resolved — **never "
+            "re-report a resolved finding** — and (b) look for new defects the fixes "
+            "themselves introduced.\n\nIf every earlier finding is resolved and you "
+            'find nothing new, return zero findings and `"patch is correct"`.'
+        )
+
+    return f"""
+> **REVIEW MODE: COMMIT SCOPE — read this first. It overrides the framing in the \
+line above and re-scopes the Instructions and Review Guidelines below.**
+
+You are **not** reviewing a proposed change. You are reviewing a change that was \
+**already merged**:
+
+- **Commit under review**: {commit_scope.commit_headline(sha)}
+- **Its diff**: `{diff_path}`
+{ancestry}
+Read that diff file first. Do **not** try to reconstruct it with `git show` or \
+`git diff` — it has already been generated correctly for you, including for merge \
+commits (where `git show` prints nothing at all).
+
+### The scope diff is historical — the code has moved on
+
+Other commits have landed since. A line number, a function, or a whole file in the \
+scope diff may no longer exist, may have been renamed, or may already have been fixed.
+
+1. Use the scope diff **only** to decide *what is in scope*: which files and which \
+behaviour the commit touched.
+2. **The current contents of the working tree are the sole authority on whether a \
+defect exists.** Before reporting anything, open the current file and confirm the \
+defect is still there. If the current code already handles it, drop the finding.
+3. Every `code_location` must be a **current** path with **current** line numbers, \
+verified by reading the file. Line numbers copied from the scope diff will be wrong.
+4. If a file in the scope diff no longer exists, skip it.
+
+### Reading the guidelines below
+
+Wherever a guideline says "this diff", read it as "the change made by \
+`{sha[:7]}`, as it manifests in the code as it exists right now". The requirement \
+that the issue be **introduced by this diff** still holds: do not flag pre-existing \
+problems, and do not flag problems introduced by *later* commits.
+
+### Fixes already applied on this branch
+
+{fixes}
+"""
+
+
+def _review_prompt_vars(config: LoopConfig, iteration: int) -> dict[str, str]:
+    """Template variables shared by all three review prompts."""
+    return {
+        "CURRENT_BRANCH": config.current_branch,
+        "TARGET_BRANCH": config.target_branch,
+        "ITERATION": str(iteration),
+        "REVIEWER_CONTEXT": _format_reviewer_context(config.reviewer_context),
+        "REVIEW_SCOPE_NOTE": _format_review_scope(config, iteration),
+    }
+
+
+def _render_review_prompt(
+    prompt_file: Path, config: LoopConfig, iteration: int
+) -> str | None:
+    """Render a review prompt, or ``None`` if it cannot be used.
+
+    In commit-scope mode a prompt that predates the feature would silently drop
+    the scope note and have the reviewer inspect an empty branch diff — which
+    reads as "no findings" rather than as a failure.  Refuse instead.
+    """
+    raw = prompt_file.read_text(encoding="utf-8")
+    if config.scope_commit and _SCOPE_NOTE_MARKER not in raw:
+        logger.error(
+            "Prompt %s predates commit-scope support (no %s marker). "
+            "Run 'overkill init' to refresh the prompt templates.",
+            prompt_file,
+            _SCOPE_NOTE_MARKER,
+        )
+        return None
+    return string.Template(raw).safe_substitute(_review_prompt_vars(config, iteration))
 
 
 # ── Review schema (single source of truth for structured output) ─────
@@ -217,15 +331,9 @@ class CodexReviewAgent(ReviewAgent):
             logger.error("Review prompt not found: %s", prompt_file)
             return False
 
-        tmpl = string.Template(
-            prompt_file.read_text(encoding="utf-8")
-        )
-        prompt_text = tmpl.safe_substitute({
-            "CURRENT_BRANCH": config.current_branch,
-            "TARGET_BRANCH": config.target_branch,
-            "ITERATION": str(iteration),
-            "REVIEWER_CONTEXT": _format_reviewer_context(config.reviewer_context),
-        })
+        prompt_text = _render_review_prompt(prompt_file, config, iteration)
+        if prompt_text is None:
+            return False
 
         if not self._budget_fn("codex", config.budget_scope, 0):
             raise BudgetTimeoutError(
@@ -323,15 +431,9 @@ class ClaudeReviewAgent(ReviewAgent):
             logger.error("Review prompt not found: %s", prompt_file)
             return False
 
-        tmpl = string.Template(
-            prompt_file.read_text(encoding="utf-8")
-        )
-        prompt_text = tmpl.safe_substitute({
-            "CURRENT_BRANCH": config.current_branch,
-            "TARGET_BRANCH": config.target_branch,
-            "ITERATION": str(iteration),
-            "REVIEWER_CONTEXT": _format_reviewer_context(config.reviewer_context),
-        })
+        prompt_text = _render_review_prompt(prompt_file, config, iteration)
+        if prompt_text is None:
+            return False
 
         if not self._budget_fn("claude", config.budget_scope, 0):
             raise BudgetTimeoutError(
@@ -426,15 +528,9 @@ class GeminiReviewAgent(ReviewAgent):
             logger.error("Review prompt not found: %s", prompt_file)
             return False
 
-        tmpl = string.Template(
-            prompt_file.read_text(encoding="utf-8")
-        )
-        prompt_text = tmpl.safe_substitute({
-            "CURRENT_BRANCH": config.current_branch,
-            "TARGET_BRANCH": config.target_branch,
-            "ITERATION": str(iteration),
-            "REVIEWER_CONTEXT": _format_reviewer_context(config.reviewer_context),
-        })
+        prompt_text = _render_review_prompt(prompt_file, config, iteration)
+        if prompt_text is None:
+            return False
 
         if not self._budget_fn("gemini", config.budget_scope, 0):
             raise BudgetTimeoutError(

--- a/src/mr_overkill/cli.py
+++ b/src/mr_overkill/cli.py
@@ -439,11 +439,12 @@ def parse_review_loop_args(
             log_dir = legacy_log
 
     # Restore saved values on resume when not explicitly given
+    restored_target = None
     if args.resume:
         if args.target is None:
             saved = log_dir / "target-branch.txt"
             if saved.is_file():
-                target = saved.read_text().strip()
+                target = restored_target = saved.read_text().strip()
         if args.max_loop is None:
             saved = log_dir / "max-loop.txt"
             if saved.is_file():
@@ -484,6 +485,12 @@ def parse_review_loop_args(
                     f"commit {restored}"
                 )
             scope_commit = restored
+            if args.target:
+                parser.error(
+                    "--commit derives its base from the commit itself; "
+                    "-t/--target cannot be combined with a resumed "
+                    "commit-scope run"
+                )
 
     if max_loop is not None and max_loop < 1:
         parser.error("--max-loop must be a positive integer")
@@ -512,11 +519,16 @@ def parse_review_loop_args(
 
     if scope_commit:
         # The work branch is created off HEAD, so the branch diff (and hence
-        # the loop's convergence check) is "the fixes so far".
-        head = resolve_commit("HEAD")
-        if head is None:
-            parser.error("--commit requires a repository with at least one commit")
-        target = head
+        # the loop's convergence check) is "the fixes so far". On resume that
+        # base was fixed when the branch was created and HEAD has since moved
+        # past it, so the restored value wins.
+        if restored_target is None:
+            head = resolve_commit("HEAD")
+            if head is None:
+                parser.error(
+                    "--commit requires a repository with at least one commit"
+                )
+            target = head
         # Every iteration commit should look normal: there is no PR to stay
         # quiet for, and no trigger commit worth saving up.
         ci_trigger_mode = "every"
@@ -524,8 +536,12 @@ def parse_review_loop_args(
     else:
         pr_number = _detect_pr_number(current_branch)
 
-    push_branch = _resolve_bool(
-        args.push, rc.get("COMMIT_SCOPE_PUSH"), scope_commit is None
+    # COMMIT_SCOPE_PUSH describes the auto-created review/* branch only; a
+    # normal branch run must always push, or its first fix commit stays local.
+    push_branch = (
+        _resolve_bool(args.push, rc.get("COMMIT_SCOPE_PUSH"), False)
+        if scope_commit
+        else True
     )
 
     return LoopConfig(

--- a/src/mr_overkill/cli.py
+++ b/src/mr_overkill/cli.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from mr_overkill import __version__
+from mr_overkill.commit_scope import resolve_commit
 from mr_overkill.models import BudgetScope, LoopConfig
 
 
@@ -109,11 +110,12 @@ def _load_rc_file(rc_name: str) -> dict[str, str]:
         "SCOPE", "AUTO_APPROVE", "CREATE_PR", "WITH_REVIEW",
         "REVIEW_LOOPS", "FIX_NITS", "REVIEWER_BACKEND",
         "REVIEWER_CONTEXT", "CI_TRIGGER_MODE", "NO_BUDGET_GATE",
+        "COMMIT_SCOPE_PUSH",
     }
     boolean_keys = {
         "DRY_RUN", "AUTO_COMMIT", "DIAGNOSTIC_LOG",
         "AUTO_APPROVE", "CREATE_PR", "WITH_REVIEW", "FIX_NITS",
-        "NO_BUDGET_GATE",
+        "NO_BUDGET_GATE", "COMMIT_SCOPE_PUSH",
     }
     kv_re = re.compile(
         r"""^\s*(\w+)=(?:"([^"]*)"|'([^']*)'|(.*?))\s*$"""
@@ -329,8 +331,39 @@ def parse_review_loop_args(
             "'none': append [skip ci] with no trigger commit."
         ),
     )
+    parser.add_argument(
+        "--commit",
+        default=None,
+        metavar="REV",
+        help=(
+            "Review an already-merged commit instead of the branch diff. "
+            "Creates a review/<sha>-<ts> branch off HEAD and applies fixes "
+            "there; no PR is created. REV is any single commit (sha, tag, "
+            "HEAD~3) — ranges are not supported. Cannot be used with -t"
+        ),
+    )
+    parser.add_argument(
+        "--push",
+        action="store_true",
+        default=None,
+        help=(
+            "Push the auto-created review branch to the remote "
+            "(default: the branch stays local)"
+        ),
+    )
 
     args = parser.parse_args(argv)
+
+    if args.commit:
+        if ".." in args.commit:
+            parser.error(
+                "--commit takes a single commit; ranges (A..B) are not supported"
+            )
+        if args.target:
+            parser.error(
+                "--commit derives its base from the commit itself; "
+                "-t/--target cannot be combined with it"
+            )
 
     # Load rc file defaults
     rc = _load_rc_file(".overkillrc")
@@ -383,7 +416,6 @@ def parse_review_loop_args(
     )
 
     current_branch = _detect_current_branch()
-    pr_number = _detect_pr_number(current_branch)
 
     # Log directory
     result = subprocess.run(
@@ -436,6 +468,23 @@ def parse_review_loop_args(
             if saved.is_file():
                 args.ci_trigger_mode = saved.read_text().strip()
 
+    scope_commit = None
+    if args.commit:
+        scope_commit = resolve_commit(args.commit)
+        if scope_commit is None:
+            parser.error(f"--commit: not a commit: {args.commit!r}")
+
+    if args.resume:
+        saved = log_dir / "scope-commit.txt"
+        if saved.is_file():
+            restored = saved.read_text().strip()
+            if scope_commit and scope_commit != restored:
+                parser.error(
+                    f"--commit {args.commit!r} differs from the resumed run's "
+                    f"commit {restored}"
+                )
+            scope_commit = restored
+
     if max_loop is not None and max_loop < 1:
         parser.error("--max-loop must be a positive integer")
 
@@ -461,6 +510,24 @@ def parse_review_loop_args(
             f" got {ci_trigger_mode!r}"
         )
 
+    if scope_commit:
+        # The work branch is created off HEAD, so the branch diff (and hence
+        # the loop's convergence check) is "the fixes so far".
+        head = resolve_commit("HEAD")
+        if head is None:
+            parser.error("--commit requires a repository with at least one commit")
+        target = head
+        # Every iteration commit should look normal: there is no PR to stay
+        # quiet for, and no trigger commit worth saving up.
+        ci_trigger_mode = "every"
+        pr_number = None
+    else:
+        pr_number = _detect_pr_number(current_branch)
+
+    push_branch = _resolve_bool(
+        args.push, rc.get("COMMIT_SCOPE_PUSH"), scope_commit is None
+    )
+
     return LoopConfig(
         current_branch=current_branch,
         target_branch=target,
@@ -484,6 +551,9 @@ def parse_review_loop_args(
         reviewer_backend=reviewer_backend,
         reviewer_context=reviewer_context,
         ci_trigger_mode=ci_trigger_mode,
+        scope_commit=scope_commit,
+        scope_diff_file=(log_dir / "scope.diff") if scope_commit else None,
+        push_branch=push_branch,
     )
 
 

--- a/src/mr_overkill/cli.py
+++ b/src/mr_overkill/cli.py
@@ -468,6 +468,10 @@ def parse_review_loop_args(
             saved = log_dir / "ci-trigger-mode.txt"
             if saved.is_file():
                 args.ci_trigger_mode = saved.read_text().strip()
+        if args.push is None:
+            saved = log_dir / "push-branch.txt"
+            if saved.is_file():
+                args.push = saved.read_text().strip() == "true"
 
     scope_commit = None
     if args.commit:

--- a/src/mr_overkill/commit_scope.py
+++ b/src/mr_overkill/commit_scope.py
@@ -1,0 +1,125 @@
+"""Commit-scope review: review an already-merged commit and improve it.
+
+The normal review loop scopes itself with ``git diff <target>...<current>``.
+A commit that already landed on the target branch is not in that diff, so the
+loop exits ``NO_DIFF`` before reviewing anything.  This module supplies the
+missing piece: it materialises the historical commit's diff to a file and
+creates a throwaway ``review/*`` branch for the fixes to land on, which lets
+the existing loop machinery run unchanged (see ``review_loop._prepare_commit_scope``).
+
+Structurally this mirrors what ``refactor_suggest`` already does — create a
+work branch, hand the reviewer a scope artefact, set ``skip_initial_no_diff``.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# ``git hash-object -t tree /dev/null`` — the canonical empty tree.  Diffing
+# against it turns a root commit (which has no parent to diff against) into a
+# plain "everything was added" patch.
+EMPTY_TREE_SHA = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
+
+def _run(cmd: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, check=False)
+
+
+def resolve_commit(rev: str, cwd: Path | None = None) -> str | None:
+    """Resolve *rev* to a full commit SHA, or ``None`` if it is not a commit.
+
+    The ``^{commit}`` peel makes annotated tags resolve to the commit they
+    point at and rejects revisions that name a tree or blob.
+    """
+    result = _run(["git", "rev-parse", "--verify", "--quiet", f"{rev}^{{commit}}"], cwd)
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def commit_base(sha: str, cwd: Path | None = None) -> str:
+    """Return the revision *sha* should be diffed against.
+
+    ``git show`` is not usable here: for a merge commit it prints a combined
+    diff, which git suppresses by default, so the patch comes out **empty**.
+    Most commits on a PR-merge branch are merge commits, so that failure would
+    be the common case rather than the exotic one.  Diffing against the first
+    parent gives a real patch for merges and is identical to ``git show`` for
+    ordinary commits.
+
+    Root commits have no parent at all; they diff against the empty tree.
+    """
+    result = _run(["git", "rev-list", "--parents", "-n", "1", sha], cwd)
+    fields = result.stdout.split()
+    if len(fields) < 2:
+        return EMPTY_TREE_SHA
+    return fields[1]
+
+
+def is_merge_commit(sha: str, cwd: Path | None = None) -> bool:
+    """True if *sha* has more than one parent."""
+    result = _run(["git", "rev-list", "--parents", "-n", "1", sha], cwd)
+    return len(result.stdout.split()) > 2
+
+
+def commit_headline(sha: str, cwd: Path | None = None) -> str:
+    """One-line description of *sha* for logs and the reviewer prompt."""
+    result = _run(
+        ["git", "log", "-1", "--format=%h — %s (%an, %ad)", "--date=short", sha],
+        cwd,
+    )
+    return result.stdout.strip() or sha
+
+
+def is_ancestor_of_head(sha: str, cwd: Path | None = None) -> bool:
+    """True if *sha* is reachable from HEAD."""
+    result = _run(["git", "merge-base", "--is-ancestor", sha, "HEAD"], cwd)
+    return result.returncode == 0
+
+
+def write_scope_diff(sha: str, output: Path, cwd: Path | None = None) -> int:
+    """Write *sha*'s diff to *output* and return the byte count.
+
+    Returns 0 when the commit is empty or git fails; the caller is expected to
+    treat that as fatal rather than reviewing nothing.
+    """
+    base = commit_base(sha, cwd)
+    result = _run(["git", "diff", base, sha], cwd)
+    if result.returncode != 0:
+        logger.error(
+            "git diff %s %s failed (exit %d): %s",
+            base,
+            sha,
+            result.returncode,
+            result.stderr.strip(),
+        )
+        return 0
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(result.stdout, encoding="utf-8")
+    return len(result.stdout.encode("utf-8"))
+
+
+def review_branch_name(sha: str) -> str:
+    """Branch name for a commit-scope run: ``review/<short-sha>-<timestamp>``."""
+    ts = datetime.now(tz=UTC).strftime("%Y%m%d-%H%M%S")
+    return f"review/{sha[:7]}-{ts}"
+
+
+def create_branch_at_head(branch: str, cwd: Path | None = None) -> bool:
+    """Create and switch to *branch* at the current HEAD.
+
+    No stash dance is needed here (unlike ``refactor_suggest``, which branches
+    from a *different* commit): branching from HEAD moves no files, so a dirty
+    working tree carries over untouched.
+    """
+    result = _run(["git", "checkout", "-b", branch], cwd)
+    if result.returncode != 0:
+        logger.error("Failed to create branch %s: %s", branch, result.stderr.strip())
+        return False
+    logger.info("Created branch: %s", branch)
+    return True

--- a/src/mr_overkill/git_ops.py
+++ b/src/mr_overkill/git_ops.py
@@ -204,9 +204,14 @@ def commit_and_push(
     snapshot: list[WorktreeSnapshot],
     message: str,
     branch: str = "",
+    push: bool = True,
     cwd: Path | None = None,
 ) -> bool:
     """Commit files changed since snapshot and push if upstream exists.
+
+    ``push=False`` keeps the commit local unconditionally.  An empty *branch*
+    is not enough for that: ``_push_current_branch`` pushes whenever an
+    upstream already exists, which a resumed review branch may well have.
 
     Returns ``True`` if a commit was made, ``False`` if nothing to commit.
     Raises ``RuntimeError`` if ``git commit`` or ``git push`` fails.
@@ -234,7 +239,10 @@ def commit_and_push(
 
     logger.info("Committed.")
 
-    _push_current_branch(branch=branch, cwd=cwd)
+    if push:
+        _push_current_branch(branch=branch, cwd=cwd)
+    else:
+        logger.info("Push disabled — commit stays local.")
     return True
 
 

--- a/src/mr_overkill/loop_engine.py
+++ b/src/mr_overkill/loop_engine.py
@@ -342,13 +342,15 @@ def review_fix_loop(
                 )
             elif had_findings and not fix_committed:
                 if config.scope_commit:
-                    # Reviewing history: "the findings needed no code change"
-                    # is a legitimate outcome (a later commit may already have
-                    # fixed them), not a broken fixer.
-                    logger.info(
-                        "No code changes were needed for the reported findings.",
+                    # The scope note tells the reviewer to confirm every
+                    # finding against the current working tree, so a no-op
+                    # fixer means confirmed defects are still unresolved —
+                    # report that rather than the generic fixer error.
+                    logger.warning(
+                        "Fixer produced no code changes for the reported "
+                        "findings — they were either stale or left unfixed.",
                     )
-                    final_status = FinalStatus.NO_DIFF
+                    final_status = FinalStatus.FINDINGS_UNFIXED
                 else:
                     logger.error(
                         "No diff after fix — previous iteration had findings but "
@@ -551,7 +553,8 @@ def review_fix_loop(
                     fix_committed = commit_and_push(
                         pre_fix_snapshot,
                         commit_msg,
-                        config.current_branch if config.push_branch else "",
+                        config.current_branch,
+                        push=config.push_branch,
                         cwd=cwd,
                     )
                 except RuntimeError as e:

--- a/src/mr_overkill/loop_engine.py
+++ b/src/mr_overkill/loop_engine.py
@@ -214,6 +214,20 @@ def review_fix_loop(
                 saved_target, config.target_branch,
             )
             return LoopResult(final_status=FinalStatus.REVIEW_FAILED, iterations_run=0)
+        # Resuming a commit-scope run as a plain review (or vice versa) would
+        # reuse logs describing a different review scope entirely.
+        scope_file = log_dir / "scope-commit.txt"
+        saved_scope = (
+            scope_file.read_text().strip() if scope_file.is_file() else ""
+        )
+        if saved_scope != (config.scope_commit or ""):
+            logger.error(
+                "Resume scope mismatch: logs are for commit '%s' "
+                "but this run has '%s'.",
+                saved_scope or "(none)",
+                config.scope_commit or "(none)",
+            )
+            return LoopResult(final_status=FinalStatus.REVIEW_FAILED, iterations_run=0)
 
         # Already-completed runs can short-circuit after branch validation
         if state.status == "completed":
@@ -322,13 +336,25 @@ def review_fix_loop(
 
         if no_diff:
             if i == 1 and config.skip_initial_no_diff:
-                logger.info("No diff on iteration 1 (expected for refactor branch).")
-            elif had_findings and not fix_committed:
-                logger.error(
-                    "No diff after fix — previous iteration had findings but "
-                    "fixer produced no code changes.",
+                logger.info(
+                    "No diff on iteration 1 "
+                    "(expected for a freshly created work branch)."
                 )
-                final_status = FinalStatus.CLAUDE_ERROR
+            elif had_findings and not fix_committed:
+                if config.scope_commit:
+                    # Reviewing history: "the findings needed no code change"
+                    # is a legitimate outcome (a later commit may already have
+                    # fixed them), not a broken fixer.
+                    logger.info(
+                        "No code changes were needed for the reported findings.",
+                    )
+                    final_status = FinalStatus.NO_DIFF
+                else:
+                    logger.error(
+                        "No diff after fix — previous iteration had findings but "
+                        "fixer produced no code changes.",
+                    )
+                    final_status = FinalStatus.CLAUDE_ERROR
                 break
             elif had_findings:
                 logger.warning(
@@ -523,7 +549,10 @@ def review_fix_loop(
                     commit_msg += f"\nSelf-review: {summary_oneline}"
                 try:
                     fix_committed = commit_and_push(
-                        pre_fix_snapshot, commit_msg, config.current_branch, cwd=cwd
+                        pre_fix_snapshot,
+                        commit_msg,
+                        config.current_branch if config.push_branch else "",
+                        cwd=cwd,
                     )
                 except RuntimeError as e:
                     logger.error("commit_and_push failed — aborting loop: %s", e)
@@ -681,6 +710,8 @@ def _save_metadata(config: LoopConfig, cwd: Path | None) -> None:
     log_dir = config.log_dir
     (log_dir / "branch.txt").write_text(config.current_branch)
     (log_dir / "target-branch.txt").write_text(config.target_branch)
+    if config.scope_commit:
+        (log_dir / "scope-commit.txt").write_text(config.scope_commit)
     (log_dir / "max-loop.txt").write_text(str(config.max_loop))
     (log_dir / "reviewer-backend.txt").write_text(config.reviewer_backend)
     (log_dir / "reviewer-context.txt").write_text(config.reviewer_context)

--- a/src/mr_overkill/loop_engine.py
+++ b/src/mr_overkill/loop_engine.py
@@ -564,6 +564,22 @@ def review_fix_loop(
                     break
                 if fix_committed and config.ci_trigger_mode in ("last-only", "none"):
                     made_skipped_fix_commit = True
+                if (
+                    not fix_committed
+                    and config.scope_commit
+                    and i == config.max_loop
+                ):
+                    # The no-diff check that catches a no-op fixer runs at
+                    # the top of the next iteration, and there is none left.
+                    # Without this, confirmed findings would report success.
+                    logger.warning(
+                        "Fixer produced no code changes on the final "
+                        "iteration — findings were either stale or left "
+                        "unfixed.",
+                    )
+                    final_status = FinalStatus.FINDINGS_UNFIXED
+                    iterations_run = i
+                    break
             else:
                 logger.info("AUTO_COMMIT is disabled — skipping commit and push.")
         finally:

--- a/src/mr_overkill/loop_engine.py
+++ b/src/mr_overkill/loop_engine.py
@@ -715,10 +715,16 @@ def _save_metadata(config: LoopConfig, cwd: Path | None) -> None:
     (log_dir / "target-branch.txt").write_text(config.target_branch)
     if config.scope_commit:
         (log_dir / "scope-commit.txt").write_text(config.scope_commit)
+        # Only commit-scope runs have a push choice to make; a resume that
+        # forgets it would silently keep the fix commits local.
+        (log_dir / "push-branch.txt").write_text(
+            "true" if config.push_branch else "false"
+        )
     else:
         # Drop a marker a prior commit-scope run left in this repo-wide
         # log dir, so --resume cannot restore an unrelated commit's scope.
         (log_dir / "scope-commit.txt").unlink(missing_ok=True)
+        (log_dir / "push-branch.txt").unlink(missing_ok=True)
     (log_dir / "max-loop.txt").write_text(str(config.max_loop))
     (log_dir / "reviewer-backend.txt").write_text(config.reviewer_backend)
     (log_dir / "reviewer-context.txt").write_text(config.reviewer_context)

--- a/src/mr_overkill/loop_engine.py
+++ b/src/mr_overkill/loop_engine.py
@@ -712,6 +712,10 @@ def _save_metadata(config: LoopConfig, cwd: Path | None) -> None:
     (log_dir / "target-branch.txt").write_text(config.target_branch)
     if config.scope_commit:
         (log_dir / "scope-commit.txt").write_text(config.scope_commit)
+    else:
+        # Drop a marker a prior commit-scope run left in this repo-wide
+        # log dir, so --resume cannot restore an unrelated commit's scope.
+        (log_dir / "scope-commit.txt").unlink(missing_ok=True)
     (log_dir / "max-loop.txt").write_text(str(config.max_loop))
     (log_dir / "reviewer-backend.txt").write_text(config.reviewer_backend)
     (log_dir / "reviewer-context.txt").write_text(config.reviewer_context)

--- a/src/mr_overkill/models.py
+++ b/src/mr_overkill/models.py
@@ -63,6 +63,7 @@ class FinalStatus(_StrEnum):
     STASH_CONFLICT = "stash_conflict"
     REVIEW_FAILED = "review_failed"
     COMMIT_PUSH_ERROR = "commit_push_error"
+    FINDINGS_UNFIXED = "findings_unfixed"
 
 
 # ── Dataclasses ──────────────────────────────────────────────────────
@@ -199,7 +200,8 @@ class LoopConfig:
     scope_commit: str | None = None
     scope_diff_file: Path | None = None
     # Whether commit_and_push may publish the branch.  Commit-scope runs
-    # create a throwaway ``review/*`` branch and keep it local by default.
+    # create a throwaway ``review/*`` branch and keep it local by default,
+    # even if that branch already has an upstream from an earlier push.
     push_branch: bool = True
 
 

--- a/src/mr_overkill/models.py
+++ b/src/mr_overkill/models.py
@@ -194,6 +194,14 @@ class LoopConfig:
     scope: str | None = None  # micro | module | layer | full
     skip_initial_no_diff: bool = False  # refactor: 1st iteration has no diff
 
+    # Commit-scope review: review an already-merged commit instead of the
+    # branch diff.  ``scope_commit`` doubles as the mode discriminator.
+    scope_commit: str | None = None
+    scope_diff_file: Path | None = None
+    # Whether commit_and_push may publish the branch.  Commit-scope runs
+    # create a throwaway ``review/*`` branch and keep it local by default.
+    push_branch: bool = True
+
 
 @dataclass(frozen=True)
 class LoopResult:

--- a/src/mr_overkill/review_loop.py
+++ b/src/mr_overkill/review_loop.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import logging
 
+from mr_overkill import commit_scope
 from mr_overkill.agents import (
     create_fix_agent,
     create_review_agent,
     create_self_review_agent,
 )
 from mr_overkill.git_ops import push_trigger_commit
-from mr_overkill.loop_engine import review_fix_loop
+from mr_overkill.loop_engine import _reject_dirty_worktree, review_fix_loop
 from mr_overkill.models import (
     FinalStatus,
     LoopConfig,
@@ -22,8 +23,88 @@ logger = logging.getLogger(__name__)
 # ── Main entry point ─────────────────────────────────────────────────
 
 
+def _prepare_commit_scope(config: LoopConfig) -> bool:
+    """Materialise the scope diff and create the review branch.
+
+    Mirrors ``refactor_suggest.run``'s preamble: guard, capture the scope
+    artefact, create a work branch, then let the loop run unchanged.
+    Returns False if the run cannot proceed.
+    """
+    sha = config.scope_commit
+    if sha is None:
+        # Not a commit-scope run: drop any scope.diff a previous one left
+        # behind, so a stale file can never be mistaken for this run's scope.
+        (config.log_dir / "scope.diff").unlink(missing_ok=True)
+        return True
+
+    if (
+        config.resume
+        and not config.dry_run
+        and not config.current_branch.startswith("review/")
+    ):
+        logger.error(
+            "Non-dry-run resume of a commit-scope run requires a review/* branch, "
+            "got '%s'.",
+            config.current_branch,
+        )
+        return False
+
+    if not config.dry_run:
+        non_allowed = _reject_dirty_worktree(None)
+        if non_allowed:
+            logger.error(
+                "Working tree is not clean. Commit or stash your changes "
+                "before running review-loop.\n  Dirty files: %s",
+                ", ".join(non_allowed),
+            )
+            return False
+
+    config.log_dir.mkdir(parents=True, exist_ok=True)
+    assert config.scope_diff_file is not None
+    size = commit_scope.write_scope_diff(sha, config.scope_diff_file)
+    if size == 0:
+        logger.error(
+            "Commit %s produces an empty diff — nothing to review.", sha[:7]
+        )
+        return False
+
+    logger.info("Commit scope: %s", commit_scope.commit_headline(sha))
+    if commit_scope.is_merge_commit(sha):
+        logger.info("Merge commit — diffed against its first parent.")
+    if not commit_scope.is_ancestor_of_head(sha):
+        logger.warning(
+            "%s is not an ancestor of HEAD — some of the code it touched "
+            "may not exist in this working tree.",
+            sha[:7],
+        )
+    logger.info("Scope diff: %s (%d bytes)", config.scope_diff_file, size)
+
+    if not config.dry_run and not config.resume:
+        branch = commit_scope.review_branch_name(sha)
+        if not commit_scope.create_branch_at_head(branch):
+            return False
+        config.current_branch = branch
+
+    # Iteration 1 has no branch diff yet: the work branch was just created.
+    config.skip_initial_no_diff = True
+
+    if config.dry_run:
+        logger.info("Dry-run — no branch created, no fixes applied.")
+    else:
+        published = "will be pushed" if config.push_branch else "local only"
+        logger.info(
+            "Fixes will land on %s (%s). No PR will be created.",
+            config.current_branch,
+            published,
+        )
+    return True
+
+
 def run(config: LoopConfig) -> int:
     """Run the review loop and return an exit code (0 = success)."""
+    if not _prepare_commit_scope(config):
+        return 1
+
     reviewer = create_review_agent(config)
     fixer = create_fix_agent(config)
     self_reviewer = (
@@ -48,12 +129,19 @@ def run(config: LoopConfig) -> int:
         and config.ci_trigger_mode == "last-only"
         and config.auto_commit
         and not config.dry_run
+        and not config.scope_commit
         and result.made_skipped_fix_commit
     ):
         try:
             push_trigger_commit(branch=config.current_branch)
         except RuntimeError as exc:
             logger.warning("Could not push CI trigger commit: %s", exc)
+
+    if config.scope_commit and not config.dry_run:
+        logger.info(
+            "Fixes are on %s. Push and open a PR when ready.",
+            config.current_branch,
+        )
 
     success_statuses = {
         FinalStatus.ALL_CLEAR,

--- a/src/mr_overkill/review_loop.py
+++ b/src/mr_overkill/review_loop.py
@@ -49,7 +49,9 @@ def _prepare_commit_scope(config: LoopConfig) -> bool:
         )
         return False
 
-    if not config.dry_run:
+    # Fresh runs only: the check keeps user WIP out of the branch about to be
+    # created. On resume the loop's own reset clears the interrupted fix first.
+    if not config.dry_run and not config.resume:
         non_allowed = _reject_dirty_worktree(None)
         if non_allowed:
             logger.error(

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import string
 from collections.abc import Callable
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -23,6 +24,8 @@ from mr_overkill.agents import (
     SelfReviewAgent,
     _budget_check,
     _BudgetFn,
+    _format_review_scope,
+    _render_review_prompt,
     create_fix_agent,
     create_review_agent,
     create_self_review_agent,
@@ -597,3 +600,149 @@ class TestFactories:
         agent = create_self_review_agent(config, fixer)
         assert isinstance(agent, ClaudeSelfReviewAgent)
         assert isinstance(agent, SelfReviewAgent)
+
+
+class TestReviewScopeNote:
+    """`${REVIEW_SCOPE_NOTE}` is empty in normal mode and load-bearing in
+    commit-scope mode."""
+
+    def _prompt(self, tmp_path: Path, marker: bool = True) -> Path:
+        p = tmp_path / "codex-review.prompt.md"
+        note = "${REVIEW_SCOPE_NOTE}\n" if marker else ""
+        p.write_text(
+            "You are a code reviewer analyzing a proposed change.\n"
+            f"{note}"
+            "## Context\n\n"
+            "- Current: ${CURRENT_BRANCH}\n- Target: ${TARGET_BRANCH}\n"
+            "- Iteration: ${ITERATION}\n${REVIEWER_CONTEXT}\n"
+        )
+        return p
+
+    def test_empty_in_normal_mode(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        config = make_loop_config()
+        assert _format_review_scope(config, 1) == ""
+
+    def test_normal_mode_render_is_unchanged(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        """Rendering must be byte-identical to substituting the legacy vars."""
+        prompt = self._prompt(tmp_path)
+        config = make_loop_config()
+        expected = string.Template(prompt.read_text()).safe_substitute({
+            "CURRENT_BRANCH": config.current_branch,
+            "TARGET_BRANCH": config.target_branch,
+            "ITERATION": "1",
+            "REVIEWER_CONTEXT": "",
+            "REVIEW_SCOPE_NOTE": "",
+        })
+        assert _render_review_prompt(prompt, config, 1) == expected
+
+    def test_commit_scope_note_is_injected(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        config = make_loop_config(
+            scope_commit="a" * 40, scope_diff_file=tmp_path / "scope.diff"
+        )
+        with (
+            patch(
+                "mr_overkill.commit_scope.commit_headline",
+                return_value="abc — x",
+            ),
+            patch(
+                "mr_overkill.commit_scope.is_ancestor_of_head",
+                return_value=True,
+            ),
+        ):
+            rendered = _render_review_prompt(self._prompt(tmp_path), config, 1)
+        assert rendered is not None
+        assert "REVIEW MODE: COMMIT SCOPE" in rendered
+        assert str(tmp_path / "scope.diff") in rendered
+        assert "sole authority" in rendered
+
+    def test_iteration_one_says_no_fixes_yet(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        config = make_loop_config(
+            scope_commit="a" * 40, scope_diff_file=tmp_path / "scope.diff"
+        )
+        with (
+            patch(
+                "mr_overkill.commit_scope.commit_headline",
+                return_value="abc — x",
+            ),
+            patch(
+                "mr_overkill.commit_scope.is_ancestor_of_head",
+                return_value=True,
+            ),
+        ):
+            note = _format_review_scope(config, 1)
+        assert "first pass" in note
+        assert "This is iteration" not in note
+
+    def test_later_iteration_describes_prior_fixes(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        """The loop only converges if the reviewer is told the branch diff is
+        its own earlier fixes, and given an explicit way to stop."""
+        config = make_loop_config(
+            scope_commit="a" * 40, scope_diff_file=tmp_path / "scope.diff"
+        )
+        with (
+            patch(
+                "mr_overkill.commit_scope.commit_headline",
+                return_value="abc — x",
+            ),
+            patch(
+                "mr_overkill.commit_scope.is_ancestor_of_head",
+                return_value=True,
+            ),
+        ):
+            note = _format_review_scope(config, 3)
+        assert "This is iteration 3" in note
+        assert "never re-report a resolved finding" in note.lower()
+        assert "patch is correct" in note
+
+    def test_non_ancestor_warning(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        config = make_loop_config(
+            scope_commit="a" * 40, scope_diff_file=tmp_path / "scope.diff"
+        )
+        with (
+            patch(
+                "mr_overkill.commit_scope.commit_headline",
+                return_value="abc — x",
+            ),
+            patch(
+                "mr_overkill.commit_scope.is_ancestor_of_head",
+                return_value=False,
+            ),
+        ):
+            note = _format_review_scope(config, 1)
+        assert "not an ancestor of HEAD" in note
+
+    def test_stale_prompt_rejected_in_commit_scope(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        """A prompt without the marker would drop the note silently and have
+        the reviewer inspect an empty branch diff — a false pass."""
+        config = make_loop_config(
+            scope_commit="a" * 40, scope_diff_file=tmp_path / "scope.diff"
+        )
+        prompt = self._prompt(tmp_path, marker=False)
+        assert _render_review_prompt(prompt, config, 1) is None
+
+    def test_stale_prompt_accepted_in_normal_mode(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        config = make_loop_config()
+        prompt = self._prompt(tmp_path, marker=False)
+        assert isinstance(_render_review_prompt(prompt, config, 1), str)
+
+    def test_shipped_prompts_carry_the_marker(self) -> None:
+        root = Path(__file__).resolve().parent.parent / "prompts" / "active"
+        for backend in ("codex", "claude", "gemini"):
+            text = (root / f"{backend}-review.prompt.md").read_text()
+            assert "${REVIEW_SCOPE_NOTE}" in text, backend

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -770,6 +770,26 @@ class TestCommitScopeArgs:
         assert config.push_branch is True
         assert config.pr_number == "42"
 
+    @patch("mr_overkill.cli._detect_pr_number", return_value="42")
+    @patch("mr_overkill.cli._detect_current_branch", return_value="feat/x")
+    @patch(
+        "mr_overkill.cli._load_rc_file",
+        return_value={"COMMIT_SCOPE_PUSH": "false"},
+    )
+    @patch("mr_overkill.cli.subprocess.run")
+    def test_normal_mode_ignores_commit_scope_push(
+        self,
+        mock_run: MagicMock,
+        mock_rc: MagicMock,
+        mock_branch: MagicMock,
+        mock_pr: MagicMock,
+    ) -> None:
+        """The rc key describes the auto-created review/* branch. Honouring it
+        here would leave the first fix commit unpushed on a fresh branch."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="/tmp/repo")
+        config = parse_review_loop_args(["-n", "1"])
+        assert config.push_branch is True
+
 
 class TestCommitScopeResume:
     """`scope-commit.txt` keeps a resumed run pointed at the same commit."""
@@ -811,3 +831,19 @@ class TestCommitScopeResume:
         (log_dir / "scope-commit.txt").write_text("f" * 40)
         with pytest.raises(SystemExit):
             self._parse(["--resume", "--commit", "abc123"], tmp_path)
+
+    def test_keeps_the_restored_target(self, tmp_path: Path) -> None:
+        """HEAD has moved past the work branch's base by the fix commits made
+        so far, so re-reading it would trip the loop's resume target check."""
+        log_dir = self._log_dir(tmp_path)
+        (log_dir / "scope-commit.txt").write_text(self.SHA)
+        config = self._parse(["--resume"], tmp_path)
+        assert config.target_branch == "d" * 40
+
+    def test_rejects_an_explicit_target(self, tmp_path: Path) -> None:
+        """The base was fixed when the work branch was created, so an explicit
+        -t can only disagree with it — say so instead of silently ignoring it."""
+        log_dir = self._log_dir(tmp_path)
+        (log_dir / "scope-commit.txt").write_text(self.SHA)
+        with pytest.raises(SystemExit):
+            self._parse(["--resume", "-t", "develop"], tmp_path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -840,6 +840,15 @@ class TestCommitScopeResume:
         config = self._parse(["--resume"], tmp_path)
         assert config.target_branch == "d" * 40
 
+    def test_restores_the_push_policy(self, tmp_path: Path) -> None:
+        """A run started with --push keeps publishing its fix commits after
+        an interruption, even though the flag is not repeated on resume."""
+        log_dir = self._log_dir(tmp_path)
+        (log_dir / "scope-commit.txt").write_text(self.SHA)
+        (log_dir / "push-branch.txt").write_text("true")
+        config = self._parse(["--resume"], tmp_path)
+        assert config.push_branch is True
+
     def test_rejects_an_explicit_target(self, tmp_path: Path) -> None:
         """The base was fixed when the work branch was created, so an explicit
         -t can only disagree with it — say so instead of silently ignoring it."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,7 @@ from mr_overkill.cli import (
     parse_refactor_suggest_args,
     parse_review_loop_args,
 )
+from mr_overkill.models import LoopConfig
 
 
 class TestResolveBool:
@@ -679,3 +680,134 @@ class TestParseRefactorSuggestArgs:
             "--reviewer-backend", "gemini",
         ])
         assert config.reviewer_backend == "gemini"
+
+
+class TestCommitScopeArgs:
+    """`--commit` / `--push` wiring for commit-scope review."""
+
+    SHA = "a" * 40
+
+    def _parse(self, argv: list[str], rc: dict[str, str] | None = None,
+               resolve: object = None) -> LoopConfig:
+        head = "b" * 40
+        default = {"HEAD": head}
+        table = {**default, **({} if resolve is None else resolve)}  # type: ignore[dict-item]
+        with (
+            patch("mr_overkill.cli._detect_pr_number", return_value="42"),
+            patch("mr_overkill.cli._detect_current_branch", return_value="main"),
+            patch("mr_overkill.cli._load_rc_file", return_value=rc or {}),
+            patch(
+                "mr_overkill.cli.subprocess.run",
+                return_value=MagicMock(returncode=0, stdout="/tmp/repo"),
+            ),
+            patch(
+                "mr_overkill.cli.resolve_commit",
+                side_effect=lambda rev: table.get(rev, self.SHA if rev else None),
+            ),
+        ):
+            return parse_review_loop_args(argv)
+
+    def test_sets_scope_fields(self) -> None:
+        config = self._parse(["-n", "2", "--commit", "abc123"])
+        assert config.scope_commit == self.SHA
+        assert config.scope_diff_file == config.log_dir / "scope.diff"
+
+    def test_target_becomes_head_sha(self) -> None:
+        config = self._parse(["-n", "2", "--commit", "abc123"])
+        assert config.target_branch == "b" * 40
+
+    def test_suppresses_pr_number(self) -> None:
+        """A review/* branch has no PR; commenting on the branch we happened
+        to start from would post findings onto an unrelated PR."""
+        config = self._parse(["-n", "2", "--commit", "abc123"])
+        assert config.pr_number is None
+
+    def test_forces_ci_trigger_every(self) -> None:
+        config = self._parse(["-n", "2", "--commit", "abc123"])
+        assert config.ci_trigger_mode == "every"
+
+    def test_branch_stays_local_by_default(self) -> None:
+        config = self._parse(["-n", "2", "--commit", "abc123"])
+        assert config.push_branch is False
+
+    def test_push_flag_opts_in(self) -> None:
+        config = self._parse(["-n", "2", "--commit", "abc123", "--push"])
+        assert config.push_branch is True
+
+    def test_push_from_rc(self) -> None:
+        config = self._parse(
+            ["-n", "2", "--commit", "abc123"], rc={"COMMIT_SCOPE_PUSH": "true"}
+        )
+        assert config.push_branch is True
+
+    def test_rejects_range_syntax(self) -> None:
+        with pytest.raises(SystemExit):
+            self._parse(["-n", "2", "--commit", "aaa..bbb"])
+
+    def test_rejects_target_combination(self) -> None:
+        with pytest.raises(SystemExit):
+            self._parse(["-n", "2", "--commit", "abc123", "-t", "main"])
+
+    def test_rejects_unresolvable_rev(self) -> None:
+        with pytest.raises(SystemExit):
+            self._parse(["-n", "2", "--commit", "nope"], resolve={"nope": None})
+
+    @patch("mr_overkill.cli._detect_pr_number", return_value="42")
+    @patch("mr_overkill.cli._detect_current_branch", return_value="feat/x")
+    @patch("mr_overkill.cli._load_rc_file", return_value={})
+    @patch("mr_overkill.cli.subprocess.run")
+    def test_normal_mode_leaves_scope_unset(
+        self,
+        mock_run: MagicMock,
+        mock_rc: MagicMock,
+        mock_branch: MagicMock,
+        mock_pr: MagicMock,
+    ) -> None:
+        mock_run.return_value = MagicMock(returncode=0, stdout="/tmp/repo")
+        config = parse_review_loop_args(["-n", "1"])
+        assert config.scope_commit is None
+        assert config.scope_diff_file is None
+        assert config.push_branch is True
+        assert config.pr_number == "42"
+
+
+class TestCommitScopeResume:
+    """`scope-commit.txt` keeps a resumed run pointed at the same commit."""
+
+    SHA = "c" * 40
+
+    def _parse(self, argv: list[str], log_dir: Path) -> LoopConfig:
+        with (
+            patch("mr_overkill.cli._detect_pr_number", return_value=None),
+            patch(
+                "mr_overkill.cli._detect_current_branch",
+                return_value="review/ccccccc-20260101-000000",
+            ),
+            patch("mr_overkill.cli._load_rc_file", return_value={}),
+            patch(
+                "mr_overkill.cli.subprocess.run",
+                return_value=MagicMock(returncode=0, stdout=str(log_dir)),
+            ),
+            patch("mr_overkill.cli.resolve_commit", side_effect=lambda rev: self.SHA),
+        ):
+            return parse_review_loop_args(argv)
+
+    def _log_dir(self, tmp_path: Path) -> Path:
+        log_dir = tmp_path / ".overkill" / "logs"
+        log_dir.mkdir(parents=True)
+        (log_dir / "max-loop.txt").write_text("3")
+        (log_dir / "target-branch.txt").write_text("d" * 40)
+        return log_dir
+
+    def test_restores_scope_commit(self, tmp_path: Path) -> None:
+        log_dir = self._log_dir(tmp_path)
+        (log_dir / "scope-commit.txt").write_text(self.SHA)
+        config = self._parse(["--resume"], tmp_path)
+        assert config.scope_commit == self.SHA
+        assert config.scope_diff_file == log_dir / "scope.diff"
+
+    def test_rejects_mismatched_commit(self, tmp_path: Path) -> None:
+        log_dir = self._log_dir(tmp_path)
+        (log_dir / "scope-commit.txt").write_text("f" * 40)
+        with pytest.raises(SystemExit):
+            self._parse(["--resume", "--commit", "abc123"], tmp_path)

--- a/tests/test_commit_scope.py
+++ b/tests/test_commit_scope.py
@@ -1,0 +1,197 @@
+"""Tests for commit_scope — run against a real git repo, not mocks.
+
+The whole point of this module is that git's own behaviour is surprising here
+(``git show`` silently prints nothing for a merge commit, root commits have no
+parent to diff against), so mocking subprocess would test our assumptions
+rather than git's actual output.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from mr_overkill.commit_scope import (
+    EMPTY_TREE_SHA,
+    commit_base,
+    commit_headline,
+    create_branch_at_head,
+    is_ancestor_of_head,
+    is_merge_commit,
+    resolve_commit,
+    review_branch_name,
+    write_scope_diff,
+)
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=True
+    )
+    return result.stdout.strip()
+
+
+def _commit(repo: Path, name: str, body: str, message: str) -> str:
+    (repo / name).write_text(body)
+    _git(repo, "add", name)
+    _git(repo, "commit", "-m", message)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def _make_merge(repo: Path) -> str:
+    """Build a real merge commit and return its SHA."""
+    base = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "checkout", "-q", "-b", "side")
+    _commit(repo, "side.txt", "from the side branch\n", "side: add file")
+    _git(repo, "checkout", "-q", "-")
+    _git(repo, "reset", "-q", "--hard", base)
+    _commit(repo, "main.txt", "from the main branch\n", "main: add file")
+    _git(repo, "merge", "--no-ff", "-m", "merge side", "side")
+    return _git(repo, "rev-parse", "HEAD")
+
+
+class TestCommitBase:
+    def test_normal_commit_uses_parent(self, tmp_git_repo: Path) -> None:
+        root = _git(tmp_git_repo, "rev-parse", "HEAD")
+        sha = _commit(tmp_git_repo, "a.txt", "hello\n", "add a")
+        assert commit_base(sha, tmp_git_repo) == root
+
+    def test_root_commit_uses_empty_tree(self, tmp_git_repo: Path) -> None:
+        root = _git(tmp_git_repo, "rev-parse", "HEAD")
+        assert commit_base(root, tmp_git_repo) == EMPTY_TREE_SHA
+
+    def test_merge_commit_uses_first_parent(self, tmp_git_repo: Path) -> None:
+        merge = _make_merge(tmp_git_repo)
+        first_parent = _git(tmp_git_repo, "rev-parse", f"{merge}^1")
+        assert commit_base(merge, tmp_git_repo) == first_parent
+
+
+class TestIsMergeCommit:
+    def test_normal(self, tmp_git_repo: Path) -> None:
+        sha = _commit(tmp_git_repo, "a.txt", "hello\n", "add a")
+        assert is_merge_commit(sha, tmp_git_repo) is False
+
+    def test_merge(self, tmp_git_repo: Path) -> None:
+        assert is_merge_commit(_make_merge(tmp_git_repo), tmp_git_repo) is True
+
+
+class TestWriteScopeDiff:
+    def test_normal_commit(self, tmp_git_repo: Path) -> None:
+        sha = _commit(tmp_git_repo, "a.txt", "hello\n", "add a")
+        out = tmp_git_repo / "scope.diff"
+        size = write_scope_diff(sha, out, tmp_git_repo)
+        assert size > 0
+        assert "+hello" in out.read_text()
+
+    def test_merge_commit_is_not_empty(self, tmp_git_repo: Path) -> None:
+        """The regression this whole module exists for.
+
+        ``git show <merge>`` prints a combined diff, which git suppresses by
+        default — the patch comes out empty.  On a PR-merge workflow that is
+        the *common* case, so an empty scope diff would silently skip the
+        review for most commits a user would want to improve.
+        """
+        merge = _make_merge(tmp_git_repo)
+        shown = subprocess.run(
+            ["git", "show", "--format=", merge],
+            cwd=tmp_git_repo,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+        assert shown.strip() == "", "precondition: git show is empty for a merge"
+
+        out = tmp_git_repo / "scope.diff"
+        assert write_scope_diff(merge, out, tmp_git_repo) > 0
+        assert "side.txt" in out.read_text()
+
+    def test_root_commit(self, tmp_git_repo: Path) -> None:
+        root = _git(tmp_git_repo, "rev-parse", "HEAD")
+        out = tmp_git_repo / "scope.diff"
+        assert write_scope_diff(root, out, tmp_git_repo) > 0
+        assert "README.md" in out.read_text()
+
+    def test_empty_commit_returns_zero(self, tmp_git_repo: Path) -> None:
+        _git(tmp_git_repo, "commit", "--allow-empty", "-m", "chore: trigger CI")
+        sha = _git(tmp_git_repo, "rev-parse", "HEAD")
+        out = tmp_git_repo / "scope.diff"
+        assert write_scope_diff(sha, out, tmp_git_repo) == 0
+
+    def test_creates_parent_directory(self, tmp_git_repo: Path) -> None:
+        sha = _commit(tmp_git_repo, "a.txt", "hello\n", "add a")
+        out = tmp_git_repo / "logs" / "nested" / "scope.diff"
+        assert write_scope_diff(sha, out, tmp_git_repo) > 0
+        assert out.is_file()
+
+
+class TestResolveCommit:
+    def test_full_and_short_sha(self, tmp_git_repo: Path) -> None:
+        sha = _commit(tmp_git_repo, "a.txt", "hello\n", "add a")
+        assert resolve_commit(sha, tmp_git_repo) == sha
+        assert resolve_commit(sha[:7], tmp_git_repo) == sha
+
+    def test_head_relative(self, tmp_git_repo: Path) -> None:
+        root = _git(tmp_git_repo, "rev-parse", "HEAD")
+        _commit(tmp_git_repo, "a.txt", "hello\n", "add a")
+        assert resolve_commit("HEAD~1", tmp_git_repo) == root
+
+    def test_annotated_tag_peels_to_commit(self, tmp_git_repo: Path) -> None:
+        sha = _commit(tmp_git_repo, "a.txt", "hello\n", "add a")
+        _git(tmp_git_repo, "tag", "-a", "v1.0", "-m", "release")
+        assert resolve_commit("v1.0", tmp_git_repo) == sha
+
+    def test_rejects_tree(self, tmp_git_repo: Path) -> None:
+        assert resolve_commit("HEAD^{tree}", tmp_git_repo) is None
+
+    def test_rejects_unknown(self, tmp_git_repo: Path) -> None:
+        assert resolve_commit("nope123", tmp_git_repo) is None
+
+
+class TestIsAncestorOfHead:
+    def test_true_for_ancestor(self, tmp_git_repo: Path) -> None:
+        root = _git(tmp_git_repo, "rev-parse", "HEAD")
+        _commit(tmp_git_repo, "a.txt", "hello\n", "add a")
+        assert is_ancestor_of_head(root, tmp_git_repo) is True
+
+    def test_false_for_sibling_branch(self, tmp_git_repo: Path) -> None:
+        base = _git(tmp_git_repo, "rev-parse", "HEAD")
+        _git(tmp_git_repo, "checkout", "-q", "-b", "side")
+        sibling = _commit(tmp_git_repo, "side.txt", "side\n", "side commit")
+        _git(tmp_git_repo, "checkout", "-q", "-")
+        _git(tmp_git_repo, "reset", "-q", "--hard", base)
+        assert is_ancestor_of_head(sibling, tmp_git_repo) is False
+
+
+class TestCommitHeadline:
+    def test_includes_subject(self, tmp_git_repo: Path) -> None:
+        sha = _commit(tmp_git_repo, "a.txt", "hello\n", "fix: something real")
+        assert "fix: something real" in commit_headline(sha, tmp_git_repo)
+
+    def test_falls_back_to_sha(self, tmp_git_repo: Path) -> None:
+        assert commit_headline("nope123", tmp_git_repo) == "nope123"
+
+
+class TestReviewBranchName:
+    def test_format(self) -> None:
+        name = review_branch_name("abcdef1234567890")
+        assert name.startswith("review/abcdef1-")
+        stamp = name.rsplit("-", 2)[-2:]
+        assert len(stamp[0]) == 8 and stamp[0].isdigit()
+        assert len(stamp[1]) == 6 and stamp[1].isdigit()
+
+
+class TestCreateBranchAtHead:
+    def test_success(self, tmp_git_repo: Path) -> None:
+        assert create_branch_at_head("review/abc-1", tmp_git_repo) is True
+        assert _git(tmp_git_repo, "rev-parse", "--abbrev-ref", "HEAD") == "review/abc-1"
+
+    def test_keeps_dirty_files(self, tmp_git_repo: Path) -> None:
+        """Branching from HEAD moves no files, so no stash dance is needed."""
+        (tmp_git_repo / "wip.txt").write_text("uncommitted\n")
+        assert create_branch_at_head("review/abc-2", tmp_git_repo) is True
+        assert (tmp_git_repo / "wip.txt").read_text() == "uncommitted\n"
+
+    def test_duplicate_name_fails(self, tmp_git_repo: Path) -> None:
+        assert create_branch_at_head("review/abc-3", tmp_git_repo) is True
+        _git(tmp_git_repo, "checkout", "-q", "-")
+        assert create_branch_at_head("review/abc-3", tmp_git_repo) is False

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 
 from mr_overkill.git_ops import (
     changed_files_since_snapshot,
+    commit_and_push,
     diff_hash,
     gen_uuid,
     git_all_dirty,
@@ -201,3 +202,66 @@ class TestPushTriggerCommit:
             "git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}",
         ]
         assert mock_run.call_args_list[2].args[0] == ["git", "push"]
+
+
+class TestCommitAndPushPushFlag:
+    """``push=False`` must skip the push outright.
+
+    An empty *branch* argument is not enough: ``_push_current_branch`` checks
+    for an upstream first and pushes whenever one exists, which a review/*
+    branch the user already published does.
+    """
+
+    def _upstream_repo(self, tmp_git_repo: Path, tmp_path: Path) -> Path:
+        """Give the repo a real remote with an upstream-tracked branch."""
+        remote = tmp_path / "remote.git"
+        subprocess.run(
+            ["git", "init", "--bare", str(remote)], check=True, capture_output=True
+        )
+        for args in (
+            ["remote", "add", "origin", str(remote)],
+            ["push", "-u", "origin", "HEAD"],
+        ):
+            subprocess.run(
+                ["git", *args], cwd=tmp_git_repo, check=True, capture_output=True
+            )
+        return remote
+
+    def _head_of(self, repo: Path) -> str:
+        return subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+
+    def test_push_false_keeps_commit_local(
+        self, tmp_git_repo: Path, tmp_path: Path
+    ) -> None:
+        remote = self._upstream_repo(tmp_git_repo, tmp_path)
+        remote_before = self._head_of(remote)
+
+        snapshot = snapshot_worktree(cwd=tmp_git_repo)
+        (tmp_git_repo / "fix.txt").write_text("a fix\n")
+
+        assert commit_and_push(
+            snapshot, "fix: local only", "", push=False, cwd=tmp_git_repo
+        ) is True
+        assert self._head_of(tmp_git_repo) != remote_before
+        assert self._head_of(remote) == remote_before
+
+    def test_push_true_publishes(
+        self, tmp_git_repo: Path, tmp_path: Path
+    ) -> None:
+        remote = self._upstream_repo(tmp_git_repo, tmp_path)
+        remote_before = self._head_of(remote)
+
+        snapshot = snapshot_worktree(cwd=tmp_git_repo)
+        (tmp_git_repo / "fix.txt").write_text("a fix\n")
+
+        assert commit_and_push(
+            snapshot, "fix: published", "", push=True, cwd=tmp_git_repo
+        ) is True
+        assert self._head_of(remote) != remote_before
+        assert self._head_of(remote) == self._head_of(tmp_git_repo)

--- a/tests/test_loop_engine.py
+++ b/tests/test_loop_engine.py
@@ -550,7 +550,7 @@ class TestLoopEngineMetadata:
 
 class TestCommitScopeLoopBehaviour:
     """Loop-side effects of commit-scope: local-only pushes, scope metadata,
-    and a no-op fix being an outcome rather than an error."""
+    and a no-op fix getting its own failure status."""
 
     @patch("mr_overkill.loop_engine.commit_and_push", return_value=True)
     @patch("mr_overkill.loop_engine.stash_allowlisted", return_value=False)
@@ -587,14 +587,15 @@ class TestCommitScopeLoopBehaviour:
     def test_push_branch_false_suppresses_push(
         self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
     ) -> None:
-        """An empty branch argument routes commit_and_push to its
-        "no upstream — skipping push" path, keeping review/* local."""
+        """push=False must bypass the push entirely — a resumed review/*
+        branch can already have an upstream, which an empty branch argument
+        would happily push to."""
         config = make_loop_config(
             max_loop=1, log_dir=tmp_path, push_branch=False,
             current_branch="review/aaaaaaa-1",
         )
         mock_commit = self._run_one_fix(config=config, tmp_path=tmp_path)
-        assert mock_commit.call_args.args[2] == ""
+        assert mock_commit.call_args.kwargs["push"] is False
 
     def test_push_branch_true_passes_branch(
         self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
@@ -604,6 +605,7 @@ class TestCommitScopeLoopBehaviour:
         )
         mock_commit = self._run_one_fix(config=config, tmp_path=tmp_path)
         assert mock_commit.call_args.args[2] == "feat/x"
+        assert mock_commit.call_args.kwargs["push"] is True
 
 
 class TestCommitScopeResumeGuard:
@@ -687,8 +689,9 @@ class TestSaveMetadataScope:
 
 
 class TestCommitScopeNoFixOutcome:
-    """A fixer that changes nothing is an error for a PR, but a legitimate
-    result when reviewing history — a later commit may already have fixed it."""
+    """A fixer that changes nothing leaves reviewer-confirmed defects in
+    place, so commit-scope reports its own failure status rather than
+    borrowing the generic fixer error."""
 
     def _run(
         self,
@@ -717,14 +720,14 @@ class TestCommitScopeNoFixOutcome:
             )
         return result.final_status
 
-    def test_commit_scope_reports_no_diff(
+    def test_commit_scope_reports_findings_unfixed(
         self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
     ) -> None:
         config = make_loop_config(
             max_loop=2, log_dir=tmp_path, scope_commit="a" * 40,
             skip_initial_no_diff=True,
         )
-        assert self._run(config, tmp_path) == FinalStatus.NO_DIFF
+        assert self._run(config, tmp_path) == FinalStatus.FINDINGS_UNFIXED
 
     def test_normal_mode_still_reports_claude_error(
         self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]

--- a/tests/test_loop_engine.py
+++ b/tests/test_loop_engine.py
@@ -7,8 +7,8 @@ from collections.abc import Callable
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from mr_overkill.loop_engine import review_fix_loop
-from mr_overkill.models import FinalStatus, LoopConfig
+from mr_overkill.loop_engine import _save_metadata, review_fix_loop
+from mr_overkill.models import FinalStatus, LoopConfig, ResumeState
 
 
 def _mock_reviewer(reviews: list[dict[str, object]]) -> MagicMock:
@@ -546,3 +546,179 @@ class TestLoopEngineMetadata:
         assert (log_dir / "branch.txt").read_text() == "feat/test"
         assert (log_dir / "target-branch.txt").read_text() == "develop"
         assert (log_dir / "max-loop.txt").read_text() == "3"
+
+
+class TestCommitScopeLoopBehaviour:
+    """Loop-side effects of commit-scope: local-only pushes, scope metadata,
+    and a no-op fix being an outcome rather than an error."""
+
+    @patch("mr_overkill.loop_engine.commit_and_push", return_value=True)
+    @patch("mr_overkill.loop_engine.stash_allowlisted", return_value=False)
+    @patch("mr_overkill.loop_engine.snapshot_worktree", return_value=[])
+    @patch("mr_overkill.loop_engine._reject_dirty_worktree", return_value=[])
+    @patch("mr_overkill.loop_engine._validate_target_branch", return_value=True)
+    @patch("mr_overkill.loop_engine._no_diff", return_value=False)
+    @patch("mr_overkill.loop_engine._save_metadata")
+    def _run_one_fix(
+        self,
+        mock_save: MagicMock,
+        mock_diff: MagicMock,
+        mock_validate: MagicMock,
+        mock_dirty: MagicMock,
+        mock_snap: MagicMock,
+        mock_stash: MagicMock,
+        mock_commit: MagicMock,
+        *,
+        config: LoopConfig,
+        tmp_path: Path,
+    ) -> MagicMock:
+        review = {
+            "findings": [{"title": "P2 something", "body": "b"}],
+            "overall_correctness": "patch is incorrect",
+        }
+        review_fix_loop(
+            config,
+            reviewer=_mock_reviewer([review, review]),
+            fixer=MagicMock(return_value=True),
+            cwd=tmp_path,
+        )
+        return mock_commit
+
+    def test_push_branch_false_suppresses_push(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        """An empty branch argument routes commit_and_push to its
+        "no upstream — skipping push" path, keeping review/* local."""
+        config = make_loop_config(
+            max_loop=1, log_dir=tmp_path, push_branch=False,
+            current_branch="review/aaaaaaa-1",
+        )
+        mock_commit = self._run_one_fix(config=config, tmp_path=tmp_path)
+        assert mock_commit.call_args.args[2] == ""
+
+    def test_push_branch_true_passes_branch(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        config = make_loop_config(
+            max_loop=1, log_dir=tmp_path, current_branch="feat/x",
+        )
+        mock_commit = self._run_one_fix(config=config, tmp_path=tmp_path)
+        assert mock_commit.call_args.args[2] == "feat/x"
+
+
+class TestCommitScopeResumeGuard:
+    @patch("mr_overkill.loop_engine.detect_state")
+    @patch("mr_overkill.loop_engine._validate_target_branch", return_value=True)
+    def test_scope_mismatch_rejected(
+        self,
+        mock_validate: MagicMock,
+        mock_detect: MagicMock,
+        tmp_path: Path,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        """Resuming a commit-scope run as a plain review would reuse logs that
+        describe a different review scope entirely."""
+        mock_detect.return_value = ResumeState(
+            status="resumable", resume_from=2, reuse_review=False
+        )
+        (tmp_path / "branch.txt").write_text("review/aaaaaaa-1")
+        (tmp_path / "target-branch.txt").write_text("main")
+        (tmp_path / "scope-commit.txt").write_text("a" * 40)
+
+        config = make_loop_config(
+            resume=True, dry_run=True, log_dir=tmp_path,
+            current_branch="review/aaaaaaa-1", target_branch="main",
+        )
+        result = review_fix_loop(
+            config, reviewer=MagicMock(), fixer=MagicMock(), cwd=tmp_path
+        )
+        assert result.final_status == FinalStatus.REVIEW_FAILED
+
+    @patch("mr_overkill.loop_engine.detect_state")
+    @patch("mr_overkill.loop_engine._validate_target_branch", return_value=True)
+    def test_matching_scope_accepted(
+        self,
+        mock_validate: MagicMock,
+        mock_detect: MagicMock,
+        tmp_path: Path,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        mock_detect.return_value = ResumeState(
+            status="completed", resume_from=2, reuse_review=False,
+            prev_status="all_clear",
+        )
+        (tmp_path / "branch.txt").write_text("review/aaaaaaa-1")
+        (tmp_path / "target-branch.txt").write_text("main")
+        (tmp_path / "scope-commit.txt").write_text("a" * 40)
+
+        config = make_loop_config(
+            resume=True, dry_run=True, log_dir=tmp_path,
+            current_branch="review/aaaaaaa-1", target_branch="main",
+            scope_commit="a" * 40,
+        )
+        result = review_fix_loop(
+            config, reviewer=MagicMock(), fixer=MagicMock(), cwd=tmp_path
+        )
+        assert result.final_status != FinalStatus.REVIEW_FAILED
+
+
+class TestSaveMetadataScope:
+    def test_writes_scope_commit(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        config = make_loop_config(log_dir=tmp_path, scope_commit="a" * 40)
+        _save_metadata(config, tmp_path)
+        assert (tmp_path / "scope-commit.txt").read_text() == "a" * 40
+
+    def test_omits_when_not_commit_scope(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        _save_metadata(make_loop_config(log_dir=tmp_path), tmp_path)
+        assert not (tmp_path / "scope-commit.txt").exists()
+
+
+class TestCommitScopeNoFixOutcome:
+    """A fixer that changes nothing is an error for a PR, but a legitimate
+    result when reviewing history — a later commit may already have fixed it."""
+
+    def _run(
+        self,
+        config: LoopConfig,
+        tmp_path: Path,
+    ) -> FinalStatus:
+        review = {
+            "findings": [{"title": "P2 something", "body": "b"}],
+            "overall_correctness": "patch is incorrect",
+        }
+        clean = {"findings": [], "overall_correctness": "patch is correct"}
+        with (
+            patch("mr_overkill.loop_engine._reject_dirty_worktree", return_value=[]),
+            patch("mr_overkill.loop_engine._validate_target_branch", return_value=True),
+            patch("mr_overkill.loop_engine._save_metadata"),
+            patch("mr_overkill.loop_engine.stash_allowlisted", return_value=False),
+            patch("mr_overkill.loop_engine.snapshot_worktree", return_value=[]),
+            patch("mr_overkill.loop_engine.commit_and_push", return_value=False),
+            patch("mr_overkill.loop_engine._no_diff", side_effect=[False, True]),
+        ):
+            result = review_fix_loop(
+                config,
+                reviewer=_mock_reviewer([review, clean]),
+                fixer=MagicMock(return_value=True),
+                cwd=tmp_path,
+            )
+        return result.final_status
+
+    def test_commit_scope_reports_no_diff(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        config = make_loop_config(
+            max_loop=2, log_dir=tmp_path, scope_commit="a" * 40,
+            skip_initial_no_diff=True,
+        )
+        assert self._run(config, tmp_path) == FinalStatus.NO_DIFF
+
+    def test_normal_mode_still_reports_claude_error(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        config = make_loop_config(max_loop=2, log_dir=tmp_path)
+        assert self._run(config, tmp_path) == FinalStatus.CLAUDE_ERROR

--- a/tests/test_loop_engine.py
+++ b/tests/test_loop_engine.py
@@ -729,8 +729,27 @@ class TestCommitScopeNoFixOutcome:
         )
         assert self._run(config, tmp_path) == FinalStatus.FINDINGS_UNFIXED
 
+    def test_findings_unfixed_on_final_iteration(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        """No iteration is left to run the no-diff check, so the commit
+        site has to report the unfixed findings itself."""
+        config = make_loop_config(
+            max_loop=1, log_dir=tmp_path, scope_commit="a" * 40,
+            skip_initial_no_diff=True,
+        )
+        assert self._run(config, tmp_path) == FinalStatus.FINDINGS_UNFIXED
+
     def test_normal_mode_still_reports_claude_error(
         self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
     ) -> None:
         config = make_loop_config(max_loop=2, log_dir=tmp_path)
         assert self._run(config, tmp_path) == FinalStatus.CLAUDE_ERROR
+
+    def test_normal_mode_final_iteration_is_not_a_failure(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        """Only commit-scope runs confirm findings against the working
+        tree, so a branch run keeps its existing exhausted-loop outcome."""
+        config = make_loop_config(max_loop=1, log_dir=tmp_path)
+        assert self._run(config, tmp_path) == FinalStatus.MAX_ITERATIONS_REACHED

--- a/tests/test_loop_engine.py
+++ b/tests/test_loop_engine.py
@@ -676,6 +676,15 @@ class TestSaveMetadataScope:
         _save_metadata(make_loop_config(log_dir=tmp_path), tmp_path)
         assert not (tmp_path / "scope-commit.txt").exists()
 
+    def test_clears_stale_scope_commit(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        """A plain run must not leave a prior commit-scope run's marker
+        behind, or a later --resume would restore an unrelated scope."""
+        (tmp_path / "scope-commit.txt").write_text("a" * 40)
+        _save_metadata(make_loop_config(log_dir=tmp_path), tmp_path)
+        assert not (tmp_path / "scope-commit.txt").exists()
+
 
 class TestCommitScopeNoFixOutcome:
     """A fixer that changes nothing is an error for a PR, but a legitimate

--- a/tests/test_review_loop.py
+++ b/tests/test_review_loop.py
@@ -354,6 +354,29 @@ class TestPrepareCommitScope:
         )
         assert _prepare_commit_scope(config) is False
 
+    @patch("mr_overkill.review_loop.commit_scope")
+    @patch("mr_overkill.review_loop._reject_dirty_worktree", return_value=["wip.py"])
+    def test_resume_leaves_the_dirty_check_to_the_loop(
+        self,
+        mock_dirty: MagicMock,
+        mock_cs: MagicMock,
+        tmp_path: Path,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        """An interrupted fix leaves partial edits behind; the loop's resume
+        reset clears them, so rejecting here would block resume entirely."""
+        mock_cs.write_scope_diff.return_value = 10
+        mock_cs.is_ancestor_of_head.return_value = True
+        mock_cs.is_merge_commit.return_value = False
+        config = self._config(
+            make_loop_config,
+            tmp_path,
+            resume=True,
+            current_branch="review/aaaaaaa-20260101-000000",
+        )
+        assert _prepare_commit_scope(config) is True
+        mock_cs.create_branch_at_head.assert_not_called()
+
     def test_normal_mode_removes_stale_scope_diff(
         self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
     ) -> None:

--- a/tests/test_review_loop.py
+++ b/tests/test_review_loop.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from mr_overkill.models import FinalStatus, LoopConfig, LoopResult
-from mr_overkill.review_loop import run
+from mr_overkill.review_loop import _prepare_commit_scope, run
 
 
 class TestReviewLoopRun:
@@ -223,3 +223,180 @@ class TestCITriggerCommit:
         config = make_loop_config(ci_trigger_mode="last-only")
         # Should still return 0 since the loop itself succeeded.
         assert run(config) == 0
+
+
+class TestPrepareCommitScope:
+    """The preamble that turns a historical commit into something the
+    existing loop can run against."""
+
+    SHA = "a" * 40
+
+    def _config(
+        self,
+        make_loop_config: Callable[..., LoopConfig],
+        tmp_path: Path,
+        **kw: object,
+    ) -> LoopConfig:
+        return make_loop_config(
+            scope_commit=self.SHA,
+            scope_diff_file=tmp_path / "logs" / "scope.diff",
+            log_dir=tmp_path / "logs",
+            **kw,
+        )
+
+    @patch("mr_overkill.review_loop.commit_scope")
+    @patch("mr_overkill.review_loop._reject_dirty_worktree", return_value=[])
+    def test_creates_branch_and_scope_diff(
+        self,
+        mock_dirty: MagicMock,
+        mock_cs: MagicMock,
+        tmp_path: Path,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        mock_cs.write_scope_diff.return_value = 1234
+        mock_cs.review_branch_name.return_value = "review/aaaaaaa-20260101-000000"
+        mock_cs.create_branch_at_head.return_value = True
+        mock_cs.is_ancestor_of_head.return_value = True
+        mock_cs.is_merge_commit.return_value = False
+
+        config = self._config(make_loop_config, tmp_path)
+        assert _prepare_commit_scope(config) is True
+        assert config.current_branch == "review/aaaaaaa-20260101-000000"
+        assert config.skip_initial_no_diff is True
+        mock_cs.write_scope_diff.assert_called_once()
+
+    @patch("mr_overkill.review_loop.commit_scope")
+    @patch("mr_overkill.review_loop._reject_dirty_worktree", return_value=[])
+    def test_dry_run_creates_no_branch(
+        self,
+        mock_dirty: MagicMock,
+        mock_cs: MagicMock,
+        tmp_path: Path,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        mock_cs.write_scope_diff.return_value = 1234
+        mock_cs.is_ancestor_of_head.return_value = True
+        mock_cs.is_merge_commit.return_value = False
+
+        config = self._config(make_loop_config, tmp_path, dry_run=True)
+        before = config.current_branch
+        assert _prepare_commit_scope(config) is True
+        mock_cs.create_branch_at_head.assert_not_called()
+        assert config.current_branch == before
+        assert config.skip_initial_no_diff is True
+
+    @patch("mr_overkill.review_loop.commit_scope")
+    @patch("mr_overkill.review_loop._reject_dirty_worktree", return_value=[])
+    def test_empty_scope_diff_aborts_before_branching(
+        self,
+        mock_dirty: MagicMock,
+        mock_cs: MagicMock,
+        tmp_path: Path,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        mock_cs.write_scope_diff.return_value = 0
+        config = self._config(make_loop_config, tmp_path)
+        assert _prepare_commit_scope(config) is False
+        mock_cs.create_branch_at_head.assert_not_called()
+
+    @patch("mr_overkill.review_loop.commit_scope")
+    @patch("mr_overkill.review_loop._reject_dirty_worktree", return_value=["wip.py"])
+    def test_dirty_worktree_aborts(
+        self,
+        mock_dirty: MagicMock,
+        mock_cs: MagicMock,
+        tmp_path: Path,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        config = self._config(make_loop_config, tmp_path)
+        assert _prepare_commit_scope(config) is False
+        mock_cs.write_scope_diff.assert_not_called()
+
+    @patch("mr_overkill.review_loop.commit_scope")
+    @patch("mr_overkill.review_loop._reject_dirty_worktree", return_value=[])
+    def test_branch_creation_failure_aborts(
+        self,
+        mock_dirty: MagicMock,
+        mock_cs: MagicMock,
+        tmp_path: Path,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        mock_cs.write_scope_diff.return_value = 10
+        mock_cs.review_branch_name.return_value = "review/x"
+        mock_cs.create_branch_at_head.return_value = False
+        mock_cs.is_ancestor_of_head.return_value = True
+        mock_cs.is_merge_commit.return_value = False
+        config = self._config(make_loop_config, tmp_path)
+        assert _prepare_commit_scope(config) is False
+
+    @patch("mr_overkill.review_loop.commit_scope")
+    @patch("mr_overkill.review_loop._reject_dirty_worktree", return_value=[])
+    def test_non_ancestor_warns_but_proceeds(
+        self,
+        mock_dirty: MagicMock,
+        mock_cs: MagicMock,
+        tmp_path: Path,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        mock_cs.write_scope_diff.return_value = 10
+        mock_cs.review_branch_name.return_value = "review/x"
+        mock_cs.create_branch_at_head.return_value = True
+        mock_cs.is_ancestor_of_head.return_value = False
+        mock_cs.is_merge_commit.return_value = False
+        config = self._config(make_loop_config, tmp_path)
+        assert _prepare_commit_scope(config) is True
+
+    def test_resume_requires_review_branch(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        config = self._config(
+            make_loop_config, tmp_path, resume=True, current_branch="main"
+        )
+        assert _prepare_commit_scope(config) is False
+
+    def test_normal_mode_removes_stale_scope_diff(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        stale = log_dir / "scope.diff"
+        stale.write_text("from a previous commit-scope run\n")
+        config = make_loop_config(log_dir=log_dir)
+        assert _prepare_commit_scope(config) is True
+        assert not stale.exists()
+
+
+class TestCommitScopeRunWiring:
+    @patch("mr_overkill.review_loop.push_trigger_commit")
+    @patch("mr_overkill.review_loop.review_fix_loop")
+    @patch("mr_overkill.review_loop._prepare_commit_scope", return_value=False)
+    def test_failed_preamble_returns_one(
+        self,
+        mock_prep: MagicMock,
+        mock_loop: MagicMock,
+        mock_trigger: MagicMock,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        assert run(make_loop_config()) == 1
+        mock_loop.assert_not_called()
+
+    @patch("mr_overkill.review_loop.push_trigger_commit")
+    @patch("mr_overkill.review_loop.review_fix_loop")
+    @patch("mr_overkill.review_loop._prepare_commit_scope", return_value=True)
+    def test_no_ci_trigger_commit_in_commit_scope(
+        self,
+        mock_prep: MagicMock,
+        mock_loop: MagicMock,
+        mock_trigger: MagicMock,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        mock_loop.return_value = LoopResult(
+            final_status=FinalStatus.ALL_CLEAR,
+            iterations_run=2,
+            made_skipped_fix_commit=True,
+        )
+        config = make_loop_config(
+            scope_commit="a" * 40, ci_trigger_mode="last-only"
+        )
+        assert run(config) == 0
+        mock_trigger.assert_not_called()


### PR DESCRIPTION
## Why

The loop scopes itself with `git diff <target>...<current>`. A commit that already landed on the target branch is not in that diff, so the run exits `NO_DIFF` before reviewing anything — there was no way to point Mr. Overkill at code already on `main` and ask it to improve it.

`-t` already accepts any git rev (`_validate_target_branch` uses `git rev-parse --verify`), so *"review everything since commit X"* worked all along; it was just undocumented. That is now in the README with examples. This PR adds the case that genuinely did not work: a **single already-merged commit**.

## How

`--commit <rev>`:

1. Writes the commit's diff to `.overkill/logs/scope.diff`.
2. Creates `review/<sha>-<ts>` off HEAD; fixes land there.
3. Sets `skip_initial_no_diff` so iteration 1 survives an empty branch diff.

From there the existing loop runs untouched — iteration 2+ sees its own fix commits as the branch diff, which is the convergence signal it already uses. Structurally identical to `refactor-suggest`, with `scope.diff` standing in for `source-files.txt`. `_no_diff`, `diff_hash`, the self-review sub-loop and the commit path are unchanged.

## Two things that needed care

**`git show` is empty for merge commits.** Git suppresses the combined diff by default, so `git show <merge>` prints no patch at all. On a PR-merge workflow that is the *common* case, so a naive implementation would have silently reviewed an empty diff for most commits worth improving — the same silent-empty-file failure as the `_generate_diff` bug in 0.8.3. The scope diff is computed against the commit's first parent instead; root commits diff against the empty tree. `test_merge_commit_is_not_empty` asserts the `git show` precondition before asserting our output, so the regression cannot come back quietly.

**The scope diff never changes, so the prompt carries the convergence contract.** The reviewer is told the diff is historical, that the current file contents are the sole authority on whether a defect still exists, that line numbers must be current, and — from iteration 2 — that the branch diff is its own earlier fixes plus an explicit way to return zero findings. Since that contract is load-bearing, the review agents **refuse to run** against a prompt template lacking the `${REVIEW_SCOPE_NOTE}` marker rather than silently dropping it and reporting a false pass.

## Smaller decisions

- The `review/*` branch stays **local** unless `--push`. "No PR" should not mean "but a branch appears on origin".
- `pr_number` is forced to `None`. `_detect_pr_number` runs against the branch you started from, so without this a `--commit` run from a branch with an open PR would comment findings about unrelated historical code onto it.
- `ci_trigger_mode` is forced to `every` — no `[skip ci]` tags and no trigger commit on a throwaway branch.
- A fixer that changes nothing reports `NO_DIFF`, not `CLAUDE_ERROR`. When reviewing history, "a later commit already fixed this" is a real outcome.
- Ranges (`A..B`) are rejected with a message rather than half-supported: branch naming, resume metadata and `..` vs `...` all fork, and the primary story is single-commit. The seam is left open.
- The three review prompts' substitution sites in `agents.py` were collapsed into one helper — they were byte-identical and had already drifted once.

## Verification

- 435 tests pass (63 new), `ruff` and `mypy --strict` clean.
- Exercised end-to-end against `2f28820`, a real merge commit in this repo: 56,452-byte scope diff (`git show` gives 0), branch created, `pr_number` `None`, `push_branch` `False`, iteration-1 branch diff confirmed empty.
- Normal-mode prompt rendering asserted **byte-identical** to before.

## Note for existing repos

Re-run `overkill init` after upgrading — `--commit` needs the refreshed review prompts. It overwrites `.overkill/prompts/active/`, so back up customised prompts first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)