### PR TITLE
feat(review-loop): --wip, review work that is not committed yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,9 @@ Worth knowing before you use it:
   `.overkill/logs/wip-base.txt`; `--wip --resume` picks an interrupted run back
   up, parking the work again if the scaffolding is already gone. A run that
   already finished is left alone. Resume needs commits enabled — the other two
-  modes are a single pass with nothing to resume.
+  modes are a single pass with nothing to resume. A *fresh* `--wip` run refuses
+  to start on top of leftover scaffolding rather than nest a second commit on
+  it, which would strand the earlier draft on the branch.
 - **A resumed run's `wip-fixes.diff` only covers the iterations after the
   resume.** Re-parking folds the earlier attempt's fixes in with your own work,
   so they cannot be told apart again; that attempt's diff is kept beside it as

--- a/README.md
+++ b/README.md
@@ -214,9 +214,14 @@ Worth knowing before you use it:
   everything unstaged.
 - **If the run is interrupted the scaffolding stays.** The command to undo it is
   printed at the start and the base commit is saved to
-  `.overkill/logs/wip-base.txt`; `--wip --resume` picks the run back up. Resume
-  needs commits enabled — the other two modes are a single pass with nothing to
-  resume.
+  `.overkill/logs/wip-base.txt`; `--wip --resume` picks an interrupted run back
+  up, parking the work again if the scaffolding is already gone. A run that
+  already finished is left alone. Resume needs commits enabled — the other two
+  modes are a single pass with nothing to resume.
+- **A resumed run's `wip-fixes.diff` only covers the iterations after the
+  resume.** Re-parking folds the earlier attempt's fixes in with your own work,
+  so they cannot be told apart again; that attempt's diff is kept beside it as
+  `wip-fixes-<sha>.diff`.
 - **Commit hooks are skipped** for the run's own commits. Work in progress
   routinely fails hooks it will pass once finished, and every commit `--wip`
   makes is torn down again.

--- a/README.md
+++ b/README.md
@@ -214,7 +214,15 @@ Worth knowing before you use it:
   everything unstaged.
 - **If the run is interrupted the scaffolding stays.** The command to undo it is
   printed at the start and the base commit is saved to
-  `.overkill/logs/wip-base.txt`; `--wip --resume` picks the run back up.
+  `.overkill/logs/wip-base.txt`; `--wip --resume` picks the run back up. Resume
+  needs commits enabled — the other two modes are a single pass with nothing to
+  resume.
+- **Commit hooks are skipped** for the run's own commits. Work in progress
+  routinely fails hooks it will pass once finished, and every commit `--wip`
+  makes is torn down again.
+- **An unfinished merge, rebase, cherry-pick or revert blocks the mode.** The
+  scaffolding commit would conclude the operation, and unwinding would then
+  reset past it.
 - **New files are included.** They are staged as intent-to-add so the reviewer
   can see them, then unstaged again.
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ Options:
                            applies fixes there; no PR is created. <rev> is a single
                            commit — ranges are not supported. Excludes -t.
   --push                   Push the auto-created review branch (default: local only)
+  --wip                    Include uncommitted working-tree changes in the review.
+                           With commits enabled they are parked in a scaffolding
+                           commit that is unwound when the run finishes, so no
+                           commit is left behind either way. Excludes --commit.
   -n, --max-loop <N>       Maximum review-fix iterations (required, unless --resume)
   --max-subloop <N>        Maximum self-review sub-iterations per fix (default: 4)
   --no-self-review         Disable self-review (equivalent to --max-subloop 0)
@@ -138,6 +142,10 @@ Examples:
   # Improve a commit that is already merged
   overkill review-loop --commit abc123 -n 1 --dry-run   # report only, no branch
   overkill review-loop --commit abc123 -n 3             # fix on a review/* branch
+
+  # Review work you have not committed yet
+  overkill review-loop --wip -n 1 --dry-run   # report only, nothing touched
+  overkill review-loop --wip -n 3             # fix it, still uncommitted at the end
 ```
 
 ### Reviewing an already-merged commit
@@ -162,10 +170,53 @@ git switch main && git pull
 overkill review-loop --commit abc123 -n 3
 ```
 
-**After upgrading, re-run `overkill init`** in each repo — `--commit` needs the
-`${REVIEW_SCOPE_NOTE}` marker that the refreshed review prompts carry, and the
-run aborts with an explanatory error if it is missing. Note that `init`
-overwrites `.overkill/prompts/active/`, so back up any customised prompts first.
+**After upgrading, re-run `overkill init`** in each repo — `--commit` and
+`--wip` need the `${REVIEW_SCOPE_NOTE}` marker that the refreshed review prompts
+carry, and the run aborts with an explanatory error if it is missing. Note that
+`init` overwrites `.overkill/prompts/active/`, so back up any customised prompts
+first.
+
+### Reviewing work you have not committed yet
+
+Without `--wip` the review scope is `git diff <target>...<current>` — committed
+work only. A dirty tree is rejected outright, and under `--dry-run` it is
+silently left out of scope. `--wip` pulls it in.
+
+How it gets there depends on whether the run is allowed to commit:
+
+| Command | Mechanism | Iterations | Commits left behind |
+|---|---|---|---|
+| `--wip --dry-run` | worktree diff written to `.overkill/logs/wip.diff` | 1 (review only) | none |
+| `--wip --no-auto-commit` | same | 1 | none |
+| `--wip` | scaffolding commit, unwound at the end | up to `-n` | none |
+
+Both paths end the same way: your working tree is dirty again, with the fixes
+applied on top of your own edits. Only the iteration count differs. Multiple
+iterations need commits because the loop detects convergence from the commit
+graph, so `--wip` parks your work in a throwaway commit, lets the loop run
+against it unchanged, and then removes the scaffolding with
+`git reset --mixed`.
+
+```bash
+overkill review-loop --wip -n 3
+git diff                              # your work plus the fixes, uncommitted
+cat .overkill/logs/wip-fixes.diff     # just what the loop changed
+```
+
+Worth knowing before you use it:
+
+- **Nothing is ever pushed** in `--wip` mode, and no PR is commented on. This is
+  not configurable — the scaffolding commit holds unfinished work.
+- **`git add -A` sweeps in anything `.gitignore` does not cover.** The file list
+  is printed before the scaffolding commit is made. Nothing is pushed and the
+  commit is unwound, but check the list if you keep untracked secrets around.
+- **A staged/unstaged split does not survive.** `git reset --mixed` leaves
+  everything unstaged.
+- **If the run is interrupted the scaffolding stays.** The command to undo it is
+  printed at the start and the base commit is saved to
+  `.overkill/logs/wip-base.txt`; `--wip --resume` picks the run back up.
+- **New files are included.** They are staged as intent-to-add so the reviewer
+  can see them, then unstaged again.
 
 ## Usage: overkill refactor-suggest
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,10 @@ Worth knowing before you use it:
   already finished is left alone. Resume needs commits enabled — the other two
   modes are a single pass with nothing to resume. A *fresh* `--wip` run refuses
   to start on top of leftover scaffolding rather than nest a second commit on
-  it, which would strand the earlier draft on the branch.
+  it, which would strand the earlier draft on the branch — including when the
+  scaffolding sits behind fix commits the interrupted run already made. A
+  resume refuses too if you have committed normally on top of it, because
+  unwinding would rewind that commit into uncommitted changes.
 - **A resumed run's `wip-fixes.diff` only covers the iterations after the
   resume.** Re-parking folds the earlier attempt's fixes in with your own work,
   so they cannot be told apart again; that attempt's diff is kept beside it as

--- a/src/mr_overkill/agents.py
+++ b/src/mr_overkill/agents.py
@@ -16,7 +16,7 @@ from abc import ABC, abstractmethod
 from importlib.resources import as_file, files
 from pathlib import Path
 
-from mr_overkill import commit_scope
+from mr_overkill import commit_scope, wip_scope
 from mr_overkill.budget import SKIP_BUDGET_ENV_VAR, budget_gate_disabled
 from mr_overkill.budget.claude import claude_budget_sufficient
 from mr_overkill.budget.codex import codex_budget_sufficient
@@ -50,9 +50,59 @@ def _format_reviewer_context(raw: str) -> str:
 
 _SCOPE_NOTE_MARKER = "${REVIEW_SCOPE_NOTE}"
 
+# Shared by both WIP mechanisms: the code under review is a draft, and the
+# reviewer has to be told so or it will report the draft-ness as the defect.
+_WIP_DRAFT_CALIBRATION = """
+### This work is unfinished
+
+It has not been committed yet, so judge it as a **draft**:
+
+- Do flag defects in what is actually written — bugs, unsafe assumptions, \
+resource leaks, debug statements or credentials left behind.
+- Do **not** flag incompleteness itself. A half-implemented feature, a missing \
+test for code still being written, or a function that is clearly the next thing \
+the author will fill in is not a finding.
+"""
+
+
+def _format_wip_scope(config: LoopConfig) -> str:
+    """Build the WIP-scope override block for whichever mechanism is in play."""
+    if config.scope_diff_file is not None:
+        # No-commit run: the branch diff shows only committed work, so it is
+        # actively misleading here — the scope artefact is the whole truth.
+        return f"""
+> **REVIEW MODE: UNCOMMITTED WORK — read this first. It overrides the framing \
+in the line above and re-scopes the Instructions below.**
+
+The change under review is the author's **uncommitted working tree**, captured \
+in full at `{config.scope_diff_file}`. Read that file first.
+
+**Ignore the `git diff` command in the Instructions section.** It compares two \
+commits, so it shows only the part of the work that happens to be committed \
+already — reviewing it would silently skip everything the author is actually \
+working on.
+
+The scope diff was taken from the working tree as it exists right now, so its \
+paths and line numbers are **current** and you may cite them directly.
+{_WIP_DRAFT_CALIBRATION}"""
+
+    # Scaffolding-commit run: the branch diff is exactly right, but the first
+    # commit's message would otherwise read as the change under review.
+    return f"""
+> **REVIEW MODE: UNCOMMITTED WORK — read this first.**
+
+The first commit on this branch, `{wip_scope.SCAFFOLD_MESSAGE}`, is not a change \
+the author wrote a commit for. It is their **uncommitted work**, parked in a \
+throwaway commit so that it can be reviewed and so that fixes have somewhere to \
+land. It will be unwound when this run finishes. Review it exactly as if the \
+author had committed it deliberately — it is the change under review.
+
+Any commit after it is a fix an earlier iteration of this loop already applied.
+{_WIP_DRAFT_CALIBRATION}"""
+
 
 def _format_review_scope(config: LoopConfig, iteration: int) -> str:
-    """Build the commit-scope override block, or "" in normal mode.
+    """Build the scope override block, or "" in normal branch-diff mode.
 
     Empty-string-means-no-section, like ``EXTRA_REVIEW_GUIDELINES`` in the
     self-review prompt.  Note ``string.Template`` does not substitute
@@ -60,7 +110,7 @@ def _format_review_scope(config: LoopConfig, iteration: int) -> str:
     """
     sha = config.scope_commit
     if not sha:
-        return ""
+        return _format_wip_scope(config) if config.wip else ""
 
     diff_path = config.scope_diff_file
     ancestry = ""
@@ -145,14 +195,14 @@ def _render_review_prompt(
 ) -> str | None:
     """Render a review prompt, or ``None`` if it cannot be used.
 
-    In commit-scope mode a prompt that predates the feature would silently drop
-    the scope note and have the reviewer inspect an empty branch diff — which
-    reads as "no findings" rather than as a failure.  Refuse instead.
+    In a scoped mode a prompt that predates the feature would silently drop the
+    scope note and have the reviewer inspect the wrong diff — which reads as
+    "no findings" rather than as a failure.  Refuse instead.
     """
     raw = prompt_file.read_text(encoding="utf-8")
-    if config.scope_commit and _SCOPE_NOTE_MARKER not in raw:
+    if (config.scope_commit or config.wip) and _SCOPE_NOTE_MARKER not in raw:
         logger.error(
-            "Prompt %s predates commit-scope support (no %s marker). "
+            "Prompt %s predates scoped review support (no %s marker). "
             "Run 'overkill init' to refresh the prompt templates.",
             prompt_file,
             _SCOPE_NOTE_MARKER,

--- a/src/mr_overkill/agents.py
+++ b/src/mr_overkill/agents.py
@@ -50,18 +50,49 @@ def _format_reviewer_context(raw: str) -> str:
 
 _SCOPE_NOTE_MARKER = "${REVIEW_SCOPE_NOTE}"
 
+
 # Shared by both WIP mechanisms: the code under review is a draft, and the
 # reviewer has to be told so or it will report the draft-ness as the defect.
-_WIP_DRAFT_CALIBRATION = """
+# Neither mechanism hands over the draft alone: both artefacts also carry the
+# author's own committed work on this branch, and that is finished code.  So the
+# subject names the draft portion and each caller carves the rest out.
+def _wip_draft_calibration(subject: str) -> str:
+    """Draft-vs-defect calibration, scoped to *subject*."""
+    return f"""
 ### This work is unfinished
 
-It has not been committed yet, so judge it as a **draft**:
+{subject} has not been committed by the author, so judge it as a **draft**:
 
 - Do flag defects in what is actually written — bugs, unsafe assumptions, \
 resource leaks, debug statements or credentials left behind.
 - Do **not** flag incompleteness itself. A half-implemented feature, a missing \
 test for code still being written, or a function that is clearly the next thing \
 the author will fill in is not a finding.
+"""
+
+
+# The no-commit WIP mechanism leaves the author's draft uncommitted, so the
+# self-review diff — ``git diff HEAD`` over the files the fixer touched — carries
+# the draft alongside the fix.  Unsaid, the self-reviewer reads the draft as the
+# fixer's work: it reports the incompleteness, or calls the draft scope creep and
+# the re-fix reverts work that exists nowhere but the working tree.
+def _wip_self_review_note(scope_diff: Path) -> str:
+    """Draft-vs-fix separation for the no-commit self-reviewer."""
+    return f"""
+
+### The diff also contains the author's uncommitted draft
+
+Nothing was committed before the fix, so the diff file shows the author's own work \
+in progress as well as the fix. The draft as it stood **before any fix ran** was \
+captured at `{scope_diff}`, so anything already written there is the author's rather \
+than the fix. That capture was taken against a different base — match it by content, \
+not by line number — and where a hunk mixes the two, the findings above say which \
+part is the fix.
+
+- Judge **only the fix**. Hunks that belong to the author's draft are out of scope.
+- Do **not** report the draft's incompleteness, and do **not** report it as scope \
+creep or ask for it to be reverted — it is not the fixer's work, and reverting it \
+would destroy uncommitted work.
 """
 
 
@@ -84,21 +115,32 @@ working on.
 
 The scope diff was taken from the working tree as it exists right now, so its \
 paths and line numbers are **current** and you may cite them directly.
-{_WIP_DRAFT_CALIBRATION}"""
 
-    # Scaffolding-commit run: the branch diff is exactly right, but the first
-    # commit's message would otherwise read as the change under review.
+It runs from this branch's fork point with `{config.target_branch}`, so it also \
+contains commits the author already made here. `git diff \
+{config.target_branch}...HEAD` prints exactly that committed portion — it is in \
+scope too, but it is finished code, so the draft allowance below does not apply \
+to it.
+{_wip_draft_calibration("The uncommitted part of the change under review")}"""
+
+    # Scaffolding-commit run: the branch diff is exactly right, but the
+    # scaffolding commit's message would otherwise read as the change under
+    # review, and it sits on top of whatever the author has already committed
+    # on this branch rather than at the bottom of the diff.
     return f"""
 > **REVIEW MODE: UNCOMMITTED WORK — read this first.**
 
-The first commit on this branch, `{wip_scope.SCAFFOLD_MESSAGE}`, is not a change \
-the author wrote a commit for. It is their **uncommitted work**, parked in a \
-throwaway commit so that it can be reviewed and so that fixes have somewhere to \
+The commit on this branch whose message is `{wip_scope.SCAFFOLD_MESSAGE}` is not a \
+change the author wrote a commit for. It is their **uncommitted work**, parked in \
+a throwaway commit so that it can be reviewed and so that fixes have somewhere to \
 land. It will be unwound when this run finishes. Review it exactly as if the \
 author had committed it deliberately — it is the change under review.
 
-Any commit after it is a fix an earlier iteration of this loop already applied.
-{_WIP_DRAFT_CALIBRATION}"""
+Commits **before** it are the author's own committed work on this branch. They are \
+in scope too, but they are finished code, so the draft allowance below does not \
+apply to them. Commits **after** it are fixes an earlier iteration of this loop \
+already applied.
+{_wip_draft_calibration("The work parked in that commit")}"""
 
 
 def _format_review_scope(config: LoopConfig, iteration: int) -> str:
@@ -737,6 +779,11 @@ class ClaudeSelfReviewAgent(SelfReviewAgent):
             budget_scope=config.budget_scope,
             dry_run=config.dry_run,
             fix_nits=config.fix_nits,
+            scope_note=(
+                _wip_self_review_note(config.scope_diff_file)
+                if config.wip and config.scope_diff_file is not None
+                else ""
+            ),
             original_review_json=json.loads(review_json_str),
         )
 

--- a/src/mr_overkill/cli.py
+++ b/src/mr_overkill/cli.py
@@ -351,6 +351,15 @@ def parse_review_loop_args(
             "(default: the branch stays local)"
         ),
     )
+    parser.add_argument(
+        "--wip",
+        action="store_true",
+        help=(
+            "Include uncommitted working-tree changes in the review. "
+            "With commits enabled they are parked in a scaffolding commit "
+            "that is unwound when the run finishes"
+        ),
+    )
 
     args = parser.parse_args(argv)
 
@@ -363,6 +372,11 @@ def parse_review_loop_args(
             parser.error(
                 "--commit derives its base from the commit itself; "
                 "-t/--target cannot be combined with it"
+            )
+        if args.wip:
+            parser.error(
+                "--commit and --wip are different review scopes; "
+                "pick one"
             )
 
     # Load rc file defaults
@@ -473,6 +487,16 @@ def parse_review_loop_args(
             if saved.is_file():
                 args.push = saved.read_text().strip() == "true"
 
+    wip_base = None
+    wip_scaffold = None
+    if args.resume and args.wip:
+        saved = log_dir / "wip-base.txt"
+        if saved.is_file():
+            wip_base = saved.read_text().strip() or None
+        saved = log_dir / "wip-scaffold.txt"
+        if saved.is_file():
+            wip_scaffold = saved.read_text().strip() or None
+
     scope_commit = None
     if args.commit:
         scope_commit = resolve_commit(args.commit)
@@ -537,6 +561,27 @@ def parse_review_loop_args(
         # quiet for, and no trigger commit worth saving up.
         ci_trigger_mode = "every"
         pr_number = None
+    elif args.wip:
+        if auto_commit and not dry_run:
+            # The scaffolding commit becomes HEAD, so a target that resolves
+            # at loop time — "HEAD", or the branch we are sitting on — would
+            # then name the scaffolding commit itself and the diff would come
+            # out empty.  Pin it to what HEAD means right now.  On resume that
+            # pinning already happened and the restored value wins.
+            if restored_target is None:
+                pinned = resolve_commit(target)
+                if pinned is None:
+                    parser.error(f"-t/--target: not a commit: {target!r}")
+                target = pinned
+        elif max_loop and max_loop > 1:
+            logging.getLogger(__name__).warning(
+                "--wip without commits runs a single iteration; "
+                "-n %d has no effect.",
+                max_loop,
+            )
+        # Findings describe uncommitted code that is not in any PR, so a
+        # comment on the branch's PR would point at nothing.
+        pr_number = None
     else:
         pr_number = _detect_pr_number(current_branch)
 
@@ -547,6 +592,10 @@ def parse_review_loop_args(
         if scope_commit
         else True
     )
+    if args.wip:
+        # Not configurable: pushing here would publish unfinished work — and
+        # the scaffolding commit holding it — to a shared branch.
+        push_branch = False
 
     return LoopConfig(
         current_branch=current_branch,
@@ -574,6 +623,9 @@ def parse_review_loop_args(
         scope_commit=scope_commit,
         scope_diff_file=(log_dir / "scope.diff") if scope_commit else None,
         push_branch=push_branch,
+        wip=args.wip,
+        wip_base=wip_base,
+        wip_scaffold=wip_scaffold,
     )
 
 

--- a/src/mr_overkill/cli.py
+++ b/src/mr_overkill/cli.py
@@ -562,6 +562,15 @@ def parse_review_loop_args(
         ci_trigger_mode = "every"
         pr_number = None
     elif args.wip:
+        if args.resume and not (auto_commit and not dry_run):
+            # Without commits a --wip run is a single pass with no state worth
+            # resuming, and resuming one would be actively harmful: the loop's
+            # resume reset stashes the very working tree being reviewed.
+            parser.error(
+                "--wip without commits is a single pass; there is nothing to "
+                "resume. Drop --resume, or allow commits so the work is "
+                "scaffolded first."
+            )
         if auto_commit and not dry_run:
             # The scaffolding commit becomes HEAD, so a target that resolves
             # at loop time — "HEAD", or the branch we are sitting on — would

--- a/src/mr_overkill/cli.py
+++ b/src/mr_overkill/cli.py
@@ -513,6 +513,17 @@ def parse_review_loop_args(
                     f"commit {restored}"
                 )
             scope_commit = restored
+            if args.wip:
+                # The mutual-exclusion check above only sees an explicit
+                # --commit. A restored one slips past it, and the resulting
+                # config takes the commit-scope branch below — leaving a
+                # --wip --no-auto-commit resume to reach the loop's resume
+                # reset, which stashes the very working tree it reviews.
+                parser.error(
+                    f"the resumed run is commit-scoped ({restored[:7]}); "
+                    "--commit and --wip are different review scopes. "
+                    "Drop --wip, or start a fresh --wip run."
+                )
             if args.target:
                 parser.error(
                     "--commit derives its base from the commit itself; "

--- a/src/mr_overkill/git_ops.py
+++ b/src/mr_overkill/git_ops.py
@@ -205,6 +205,7 @@ def commit_and_push(
     message: str,
     branch: str = "",
     push: bool = True,
+    no_verify: bool = False,
     cwd: Path | None = None,
 ) -> bool:
     """Commit files changed since snapshot and push if upstream exists.
@@ -212,6 +213,9 @@ def commit_and_push(
     ``push=False`` keeps the commit local unconditionally.  An empty *branch*
     is not enough for that: ``_push_current_branch`` pushes whenever an
     upstream already exists, which a resumed review branch may well have.
+
+    ``no_verify=True`` skips commit hooks.  Only throwaway commits should ask
+    for it — see the WIP scaffolding in ``wip_scope``.
 
     Returns ``True`` if a commit was made, ``False`` if nothing to commit.
     Raises ``RuntimeError`` if ``git commit`` or ``git push`` fails.
@@ -230,7 +234,11 @@ def commit_and_push(
 
     # Commit
     result = _run(
-        ["git", "commit", "-m", message, "--pathspec-from-file=-"],
+        [
+            "git", "commit",
+            *(["--no-verify"] if no_verify else []),
+            "-m", message, "--pathspec-from-file=-",
+        ],
         cwd=cwd,
         input=pathspec,
     )

--- a/src/mr_overkill/loop_engine.py
+++ b/src/mr_overkill/loop_engine.py
@@ -12,6 +12,7 @@ import subprocess
 from pathlib import Path
 from typing import Protocol
 
+from mr_overkill import wip_scope
 from mr_overkill.git_ops import (
     commit_and_push,
     diff_hash,
@@ -132,6 +133,10 @@ def _normalize_paths(review: dict[str, object], cwd: Path | None) -> dict[str, o
 
 # ── Main loop engine ─────────────────────────────────────────────────
 
+#: Subject prefix of the loop's fix commits. ``_prepare_wip_scope`` needs
+#: the same one to ask ``detect_state`` what this run is resuming.
+DEFAULT_COMMIT_PATTERN = "fix(ai-review): apply iteration"
+
 
 def review_fix_loop(
     config: LoopConfig,
@@ -140,7 +145,7 @@ def review_fix_loop(
     fixer: FixFn,
     self_reviewer: SelfReviewFn | None = None,
     pre_fix_confirm: PreFixConfirmFn | None = None,
-    commit_pattern: str = "fix(ai-review): apply iteration",
+    commit_pattern: str = DEFAULT_COMMIT_PATTERN,
     cwd: Path | None = None,
 ) -> LoopResult:
     """Run the review-fix loop.
@@ -763,10 +768,7 @@ def _save_metadata(config: LoopConfig, cwd: Path | None) -> None:
         (log_dir / "scope-commit.txt").unlink(missing_ok=True)
         (log_dir / "push-branch.txt").unlink(missing_ok=True)
     if config.wip_base:
-        # An interrupted --wip run is only recoverable while these survive:
-        # they are the sole record of where to unwind the scaffolding to.
-        (log_dir / "wip-base.txt").write_text(config.wip_base)
-        (log_dir / "wip-scaffold.txt").write_text(config.wip_scaffold or "")
+        wip_scope.save_metadata(log_dir, config.wip_base, config.wip_scaffold)
     else:
         (log_dir / "wip-base.txt").unlink(missing_ok=True)
         (log_dir / "wip-scaffold.txt").unlink(missing_ok=True)

--- a/src/mr_overkill/loop_engine.py
+++ b/src/mr_overkill/loop_engine.py
@@ -572,6 +572,10 @@ def review_fix_loop(
                         commit_msg,
                         config.current_branch,
                         push=config.push_branch,
+                        # A --wip run's commits all get torn down again, and
+                        # they carry the same unfinished work the scaffolding
+                        # commit had to skip hooks for.
+                        no_verify=config.wip,
                         cwd=cwd,
                     )
                 except RuntimeError as e:

--- a/src/mr_overkill/loop_engine.py
+++ b/src/mr_overkill/loop_engine.py
@@ -592,12 +592,16 @@ def review_fix_loop(
                     made_skipped_fix_commit = True
                 if (
                     not fix_committed
-                    and config.scope_commit
+                    and (config.scope_commit or config.wip)
                     and i == config.max_loop
                 ):
                     # The no-diff check that catches a no-op fixer runs at
                     # the top of the next iteration, and there is none left.
                     # Without this, confirmed findings would report success.
+                    # A --wip run needs this even more than a commit-scope
+                    # one: its target is pinned before the scaffolding
+                    # commit, so the branch diff always holds the parked
+                    # work and that check can never fire at all.
                     logger.warning(
                         "Fixer produced no code changes on the final "
                         "iteration — findings were either stale or left "

--- a/src/mr_overkill/loop_engine.py
+++ b/src/mr_overkill/loop_engine.py
@@ -228,6 +228,19 @@ def review_fix_loop(
                 config.scope_commit or "(none)",
             )
             return LoopResult(final_status=FinalStatus.REVIEW_FAILED, iterations_run=0)
+        # Resuming a scaffolded --wip run without its base would leave the
+        # scaffolding commit behind for good; resuming a plain run as --wip
+        # would scaffold on top of someone else's logs.
+        wip_file = log_dir / "wip-base.txt"
+        saved_wip = wip_file.read_text().strip() if wip_file.is_file() else ""
+        if saved_wip != (config.wip_base or ""):
+            logger.error(
+                "Resume WIP mismatch: logs were scaffolded at '%s' "
+                "but this run has '%s'.",
+                saved_wip or "(none)",
+                config.wip_base or "(none)",
+            )
+            return LoopResult(final_status=FinalStatus.REVIEW_FAILED, iterations_run=0)
 
         # Already-completed runs can short-circuit after branch validation
         if state.status == "completed":
@@ -285,13 +298,17 @@ def review_fix_loop(
 
     # ── Clean working tree check ────────────────────────────────────
     # Reject non-allowlisted dirty files in non-dry-run mode to prevent
-    # user WIP from being mixed into AI auto-fix commits.
-    if not config.dry_run:
+    # user WIP from being mixed into AI auto-fix commits.  A --wip run that
+    # makes no commits has nothing to mix them into, so the check does not
+    # apply there; a --wip run that does commit has already parked the work
+    # in its scaffolding commit and reaches this point with a clean tree.
+    if not config.dry_run and not (config.wip and not config.auto_commit):
         non_allowed = _reject_dirty_worktree(cwd)
         if non_allowed:
             logger.error(
                 "Working tree is not clean. Commit or stash your changes "
-                "before running review-loop.\n  Dirty files: %s",
+                "before running review-loop, or pass --wip to include them "
+                "in the review.\n  Dirty files: %s",
                 ", ".join(non_allowed),
             )
             return LoopResult(
@@ -741,6 +758,14 @@ def _save_metadata(config: LoopConfig, cwd: Path | None) -> None:
         # log dir, so --resume cannot restore an unrelated commit's scope.
         (log_dir / "scope-commit.txt").unlink(missing_ok=True)
         (log_dir / "push-branch.txt").unlink(missing_ok=True)
+    if config.wip_base:
+        # An interrupted --wip run is only recoverable while these survive:
+        # they are the sole record of where to unwind the scaffolding to.
+        (log_dir / "wip-base.txt").write_text(config.wip_base)
+        (log_dir / "wip-scaffold.txt").write_text(config.wip_scaffold or "")
+    else:
+        (log_dir / "wip-base.txt").unlink(missing_ok=True)
+        (log_dir / "wip-scaffold.txt").unlink(missing_ok=True)
     (log_dir / "max-loop.txt").write_text(str(config.max_loop))
     (log_dir / "reviewer-backend.txt").write_text(config.reviewer_backend)
     (log_dir / "reviewer-context.txt").write_text(config.reviewer_context)

--- a/src/mr_overkill/models.py
+++ b/src/mr_overkill/models.py
@@ -212,6 +212,9 @@ class LoopConfig:
     wip: bool = False
     wip_base: str | None = None  # HEAD before scaffolding — the unwind target
     wip_scaffold: str | None = None  # the scaffolding commit itself
+    # Cleared when a run keeps the recorded metadata but scaffolds nothing, so
+    # the unwind cannot mistake an unrelated HEAD for scaffolding of its own.
+    wip_unwind: bool = True
 
 
 @dataclass(frozen=True)

--- a/src/mr_overkill/models.py
+++ b/src/mr_overkill/models.py
@@ -198,11 +198,20 @@ class LoopConfig:
     # Commit-scope review: review an already-merged commit instead of the
     # branch diff.  ``scope_commit`` doubles as the mode discriminator.
     scope_commit: str | None = None
+    # Path of the scope artefact for whichever scope mode is active:
+    # ``scope.diff`` for commit scope, ``wip.diff`` for WIP scope.
     scope_diff_file: Path | None = None
     # Whether commit_and_push may publish the branch.  Commit-scope runs
     # create a throwaway ``review/*`` branch and keep it local by default,
     # even if that branch already has an upstream from an earlier push.
     push_branch: bool = True
+
+    # WIP scope: pull uncommitted working-tree changes into the review.  With
+    # commits allowed the work is parked in a scaffolding commit that is torn
+    # down afterwards; without them the reviewer gets a worktree diff instead.
+    wip: bool = False
+    wip_base: str | None = None  # HEAD before scaffolding — the unwind target
+    wip_scaffold: str | None = None  # the scaffolding commit itself
 
 
 @dataclass(frozen=True)

--- a/src/mr_overkill/review_loop.py
+++ b/src/mr_overkill/review_loop.py
@@ -251,6 +251,20 @@ def _prepare_wip_scope(config: LoopConfig) -> bool:
     if head is None:
         logger.error("--wip requires a repository with at least one commit.")
         return False
+    # Only on a fresh run: the re-park path above already proved HEAD is the
+    # recorded base, and a leftover scaffolding commit *is* what it re-parks
+    # onto, so refusing there would block the very resume this points at.
+    if not config.resume and wip_scope.head_is_scaffold():
+        logger.error(
+            "HEAD is already a scaffolding commit (%s) — an earlier --wip run "
+            "was interrupted before it could unwind. Scaffolding on top of it "
+            "would leave that commit, and the work parked in it, on the branch "
+            "for good. Either pick that run up with --resume, or undo it "
+            "first:\n  git reset --mixed %s^",
+            head[:7],
+            head,
+        )
+        return False
     scaffold = wip_scope.create_scaffold_commit()
     if scaffold is None:
         return False

--- a/src/mr_overkill/review_loop.py
+++ b/src/mr_overkill/review_loop.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 
-from mr_overkill import commit_scope
+from mr_overkill import commit_scope, wip_scope
 from mr_overkill.agents import (
     create_fix_agent,
     create_review_agent,
@@ -102,9 +102,113 @@ def _prepare_commit_scope(config: LoopConfig) -> bool:
     return True
 
 
+def _wip_commits_allowed(config: LoopConfig) -> bool:
+    """Whether a WIP run may park the work in a scaffolding commit."""
+    return config.auto_commit and not config.dry_run
+
+
+def _prepare_wip_scope(config: LoopConfig) -> bool:
+    """Bring uncommitted work into the review scope.
+
+    Two mechanisms, picked by whether this run may commit: a worktree diff the
+    reviewer reads as its scope, or a scaffolding commit that puts the work on
+    the branch so the loop's commit-graph machinery sees it.  Returns False if
+    the run cannot proceed.
+    """
+    wip_diff = config.log_dir / "wip.diff"
+    if not config.wip:
+        # Drop a previous WIP run's artefact so it can never be mistaken for
+        # this run's scope.
+        wip_diff.unlink(missing_ok=True)
+        return True
+
+    if config.resume and _wip_commits_allowed(config):
+        if not config.wip_base:
+            logger.error(
+                "Cannot resume a --wip run: the scaffolding commit's base is "
+                "missing from %s.",
+                config.log_dir / "wip-base.txt",
+            )
+            return False
+        logger.info(
+            "Resuming a --wip run — scaffolding commit %s is already in place.",
+            (config.wip_scaffold or "?")[:7],
+        )
+        return True
+
+    dirty = wip_scope.uncommitted_files()
+    if not dirty:
+        logger.error(
+            "--wip: the working tree is clean — there is no uncommitted "
+            "work to review.",
+        )
+        return False
+    logger.info("WIP scope: %d uncommitted file(s).", len(dirty))
+
+    config.log_dir.mkdir(parents=True, exist_ok=True)
+
+    if not _wip_commits_allowed(config):
+        config.scope_diff_file = wip_diff
+        size = wip_scope.write_worktree_diff(config.target_branch, wip_diff)
+        if size == 0:
+            logger.error("Could not capture the working-tree diff — nothing to review.")
+            return False
+        logger.info("Scope diff: %s (%d bytes)", wip_diff, size)
+        # The branch itself may hold no commits at all; the scope lives in the
+        # artefact, not in the branch diff.
+        config.skip_initial_no_diff = True
+        logger.info(
+            "No commits will be made — fixes stay in the working tree.",
+        )
+        return True
+
+    # Scaffolding path: nothing reads wip.diff here, and a stale one would be
+    # misleading if this run is later inspected.
+    wip_diff.unlink(missing_ok=True)
+
+    if config.current_branch in ("main", "master", "develop"):
+        logger.warning(
+            "You are on '%s'. The scaffolding commit lands there until it is "
+            "unwound at the end of the run. It is never pushed.",
+            config.current_branch,
+        )
+
+    head = commit_scope.resolve_commit("HEAD")
+    if head is None:
+        logger.error("--wip requires a repository with at least one commit.")
+        return False
+    scaffold = wip_scope.create_scaffold_commit()
+    if scaffold is None:
+        return False
+    config.wip_base = head
+    config.wip_scaffold = scaffold
+    logger.warning(
+        "If this run is interrupted the scaffolding stays behind. Undo it with:"
+        "\n  git reset --mixed %s",
+        head,
+    )
+    return True
+
+
+def _unwind_wip_scope(config: LoopConfig) -> None:
+    """Remove the scaffolding, leaving the work uncommitted again."""
+    if not config.wip or not config.wip_base:
+        return
+    if not wip_scope.unwind(
+        config.wip_base, config.wip_scaffold, config.log_dir
+    ):
+        logger.error(
+            "Working tree contents are intact, but the scaffolding commit is "
+            "still there. Run: git reset --mixed %s",
+            config.wip_base,
+        )
+
+
 def run(config: LoopConfig) -> int:
     """Run the review loop and return an exit code (0 = success)."""
     if not _prepare_commit_scope(config):
+        return 1
+    if not _prepare_wip_scope(config):
         return 1
 
     reviewer = create_review_agent(config)
@@ -115,12 +219,17 @@ def run(config: LoopConfig) -> int:
         else None
     )
 
-    result = review_fix_loop(
-        config,
-        reviewer=reviewer,
-        fixer=fixer,
-        self_reviewer=self_reviewer,
-    )
+    try:
+        result = review_fix_loop(
+            config,
+            reviewer=reviewer,
+            fixer=fixer,
+            self_reviewer=self_reviewer,
+        )
+    finally:
+        # The scaffolding has to come down however the loop ended — a failure
+        # that left it in place would be indistinguishable from real commits.
+        _unwind_wip_scope(config)
 
     logger.info("Done. Status: %s", result.final_status)
     if result.summary_path:
@@ -132,6 +241,7 @@ def run(config: LoopConfig) -> int:
         and config.auto_commit
         and not config.dry_run
         and not config.scope_commit
+        and not config.wip
         and result.made_skipped_fix_commit
     ):
         try:
@@ -143,6 +253,12 @@ def run(config: LoopConfig) -> int:
         logger.info(
             "Fixes are on %s. Push and open a PR when ready.",
             config.current_branch,
+        )
+
+    if config.wip and not config.dry_run:
+        logger.info(
+            "Fixes are in your working tree, uncommitted. Review them with "
+            "'git diff' before committing.",
         )
 
     success_statuses = {

--- a/src/mr_overkill/review_loop.py
+++ b/src/mr_overkill/review_loop.py
@@ -173,6 +173,17 @@ def _prepare_wip_scope(config: LoopConfig) -> bool:
             config.current_branch,
         )
 
+    in_progress = wip_scope.operation_in_progress()
+    if in_progress:
+        logger.error(
+            "A %s is in progress. The scaffolding commit would conclude it, "
+            "and unwinding would then reset past it. Finish or abort the %s "
+            "first.",
+            in_progress,
+            in_progress,
+        )
+        return False
+
     head = commit_scope.resolve_commit("HEAD")
     if head is None:
         logger.error("--wip requires a repository with at least one commit.")
@@ -190,18 +201,18 @@ def _prepare_wip_scope(config: LoopConfig) -> bool:
     return True
 
 
-def _unwind_wip_scope(config: LoopConfig) -> None:
+def _unwind_wip_scope(config: LoopConfig) -> bool:
     """Remove the scaffolding, leaving the work uncommitted again."""
     if not config.wip or not config.wip_base:
-        return
-    if not wip_scope.unwind(
-        config.wip_base, config.wip_scaffold, config.log_dir
-    ):
-        logger.error(
-            "Working tree contents are intact, but the scaffolding commit is "
-            "still there. Run: git reset --mixed %s",
-            config.wip_base,
-        )
+        return True
+    if wip_scope.unwind(config.wip_base, config.wip_scaffold, config.log_dir):
+        return True
+    logger.error(
+        "Working tree contents are intact, but the scaffolding commit is "
+        "still there. Run: git reset --mixed %s",
+        config.wip_base,
+    )
+    return False
 
 
 def run(config: LoopConfig) -> int:
@@ -219,6 +230,7 @@ def run(config: LoopConfig) -> int:
         else None
     )
 
+    unwound = True
     try:
         result = review_fix_loop(
             config,
@@ -229,7 +241,7 @@ def run(config: LoopConfig) -> int:
     finally:
         # The scaffolding has to come down however the loop ended — a failure
         # that left it in place would be indistinguishable from real commits.
-        _unwind_wip_scope(config)
+        unwound = _unwind_wip_scope(config)
 
     logger.info("Done. Status: %s", result.final_status)
     if result.summary_path:
@@ -260,6 +272,11 @@ def run(config: LoopConfig) -> int:
             "Fixes are in your working tree, uncommitted. Review them with "
             "'git diff' before committing.",
         )
+
+    if not unwound:
+        # Reporting success would tell a caller the run left no commits
+        # behind when it demonstrably did.
+        return 1
 
     success_statuses = {
         FinalStatus.ALL_CLEAR,

--- a/src/mr_overkill/review_loop.py
+++ b/src/mr_overkill/review_loop.py
@@ -121,12 +121,6 @@ def _prepare_wip_scope(config: LoopConfig) -> bool:
     the run cannot proceed.
     """
     wip_diff = config.log_dir / "wip.diff"
-    if not config.resume:
-        # Only ``unwind`` writes this, at the very end of a committing run, so
-        # a leftover one always belongs to a previous run — and the README
-        # points users at it for "just what the loop changed".
-        for stale in config.log_dir.glob("wip-fixes*.diff"):
-            stale.unlink()
     if not config.wip:
         # Drop a previous WIP run's artefact so it can never be mistaken for
         # this run's scope.
@@ -184,6 +178,22 @@ def _prepare_wip_scope(config: LoopConfig) -> bool:
             )
             return False
         if config.wip_scaffold and wip_scope.is_in_head(config.wip_scaffold):
+            # The unwind resets to the base, so everything stacked on the
+            # scaffolding goes with it.  Being on the right branch does not
+            # make those commits this loop's — a normal commit made on top of
+            # an interrupted run would be rewound into uncommitted changes.
+            foreign = wip_scope.foreign_commits_since(
+                config.wip_scaffold, DEFAULT_COMMIT_PATTERN
+            )
+            if foreign:
+                logger.error(
+                    "Cannot resume a --wip run: %d commit(s) after the "
+                    "scaffolding are not this loop's, and unwinding would "
+                    "reset them back into uncommitted changes. First: %s",
+                    len(foreign),
+                    foreign[-1],
+                )
+                return False
             logger.info(
                 "Resuming a --wip run — scaffolding commit %s is already in "
                 "place.",
@@ -279,17 +289,26 @@ def _prepare_wip_scope(config: LoopConfig) -> bool:
     # Only on a fresh run: the re-park path above already proved HEAD is the
     # recorded base, and a leftover scaffolding commit *is* what it re-parks
     # onto, so refusing there would block the very resume this points at.
-    if not config.resume and wip_scope.head_is_scaffold():
+    leftover = None if config.resume else wip_scope.find_scaffold_in_head()
+    if leftover:
         logger.error(
-            "HEAD is already a scaffolding commit (%s) — an earlier --wip run "
-            "was interrupted before it could unwind. Scaffolding on top of it "
-            "would leave that commit, and the work parked in it, on the branch "
-            "for good. Either pick that run up with --resume, or undo it "
-            "first:\n  git reset --mixed %s^",
-            head[:7],
-            head,
+            "Scaffolding commit %s is still in this branch's history — an "
+            "earlier --wip run was interrupted before it could unwind. "
+            "Scaffolding on top of it would leave that commit, and the work "
+            "parked in it, on the branch for good. Either pick that run up "
+            "with --resume, or undo it first:\n  git reset --mixed %s^",
+            leftover[:7],
+            leftover,
         )
         return False
+    if not config.resume:
+        # Only ``unwind`` writes these, at the very end of a committing run, so
+        # a leftover one always belongs to a previous run — and the README
+        # points users at it for "just what the loop changed".  Deferred to the
+        # point of no return: every abort path above leaves it where the README
+        # says it is, because a run that stops there writes no replacement.
+        for stale in config.log_dir.glob("wip-fixes*.diff"):
+            stale.unlink()
     scaffold = wip_scope.create_scaffold_commit()
     if scaffold is None:
         return False

--- a/src/mr_overkill/review_loop.py
+++ b/src/mr_overkill/review_loop.py
@@ -133,6 +133,22 @@ def _prepare_wip_scope(config: LoopConfig) -> bool:
         wip_diff.unlink(missing_ok=True)
         return True
 
+    if _wip_commits_allowed(config):
+        # Ahead of every path below, including the resume short-circuits: this
+        # run may commit, and a commit made during an unfinished operation
+        # concludes it — while the unwind's reset drops its metadata. A resume
+        # whose scaffolding is still in HEAD would otherwise skip the check.
+        in_progress = wip_scope.operation_in_progress()
+        if in_progress:
+            logger.error(
+                "A %s is in progress. The scaffolding commit would conclude "
+                "it, and unwinding would then reset past it. Finish or abort "
+                "the %s first.",
+                in_progress,
+                in_progress,
+            )
+            return False
+
     # Set only when this run re-parks work a previous one left uncommitted;
     # a clean tree means something different there.
     reparking_from: str | None = None
@@ -140,6 +156,26 @@ def _prepare_wip_scope(config: LoopConfig) -> bool:
     # wip-fixes.diff belongs to.
     previous_scaffold: str | None = None
     if config.resume and _wip_commits_allowed(config):
+        # Before anything reads the recorded SHAs: the scaffolding commit is
+        # also in the history of every branch cut from it, so ancestry alone
+        # would let a resume on one of those reach the unwind and reset its
+        # commits away.  The branch the scaffolding was made on is the only
+        # thing that identifies it.
+        branch_file = config.log_dir / "branch.txt"
+        scaffolded_branch = (
+            branch_file.read_text().strip() if branch_file.is_file() else ""
+        )
+        if scaffolded_branch != config.current_branch:
+            logger.error(
+                "Cannot resume a --wip run here: the scaffolding was made on "
+                "'%s' but you are on '%s'. Unwinding would reset '%s' back to "
+                "the recorded base. Switch back to '%s' first.",
+                scaffolded_branch or "(unrecorded)",
+                config.current_branch,
+                config.current_branch,
+                scaffolded_branch or "the original branch",
+            )
+            return False
         if not config.wip_base:
             logger.error(
                 "Cannot resume a --wip run: the scaffolding commit's base is "
@@ -236,17 +272,6 @@ def _prepare_wip_scope(config: LoopConfig) -> bool:
             config.current_branch,
         )
 
-    in_progress = wip_scope.operation_in_progress()
-    if in_progress:
-        logger.error(
-            "A %s is in progress. The scaffolding commit would conclude it, "
-            "and unwinding would then reset past it. Finish or abort the %s "
-            "first.",
-            in_progress,
-            in_progress,
-        )
-        return False
-
     head = commit_scope.resolve_commit("HEAD")
     if head is None:
         logger.error("--wip requires a repository with at least one commit.")
@@ -303,7 +328,12 @@ def _unwind_wip_scope(config: LoopConfig) -> bool:
     # other run made.
     if not _wip_commits_allowed(config):
         return True
-    if wip_scope.unwind(config.wip_base, config.wip_scaffold, config.log_dir):
+    if wip_scope.unwind(
+        config.wip_base,
+        config.wip_scaffold,
+        config.log_dir,
+        branch=config.current_branch,
+    ):
         return True
     logger.error(
         "Working tree contents are intact, but the scaffolding commit is "

--- a/src/mr_overkill/review_loop.py
+++ b/src/mr_overkill/review_loop.py
@@ -11,11 +11,16 @@ from mr_overkill.agents import (
     create_self_review_agent,
 )
 from mr_overkill.git_ops import push_trigger_commit
-from mr_overkill.loop_engine import _reject_dirty_worktree, review_fix_loop
+from mr_overkill.loop_engine import (
+    DEFAULT_COMMIT_PATTERN,
+    _reject_dirty_worktree,
+    review_fix_loop,
+)
 from mr_overkill.models import (
     FinalStatus,
     LoopConfig,
 )
+from mr_overkill.resume import detect_state
 
 logger = logging.getLogger(__name__)
 
@@ -116,12 +121,24 @@ def _prepare_wip_scope(config: LoopConfig) -> bool:
     the run cannot proceed.
     """
     wip_diff = config.log_dir / "wip.diff"
+    if not config.resume:
+        # Only ``unwind`` writes this, at the very end of a committing run, so
+        # a leftover one always belongs to a previous run — and the README
+        # points users at it for "just what the loop changed".
+        for stale in config.log_dir.glob("wip-fixes*.diff"):
+            stale.unlink()
     if not config.wip:
         # Drop a previous WIP run's artefact so it can never be mistaken for
         # this run's scope.
         wip_diff.unlink(missing_ok=True)
         return True
 
+    # Set only when this run re-parks work a previous one left uncommitted;
+    # a clean tree means something different there.
+    reparking_from: str | None = None
+    # The scaffolding this run re-parks away from: it is what the existing
+    # wip-fixes.diff belongs to.
+    previous_scaffold: str | None = None
     if config.resume and _wip_commits_allowed(config):
         if not config.wip_base:
             logger.error(
@@ -130,11 +147,40 @@ def _prepare_wip_scope(config: LoopConfig) -> bool:
                 config.log_dir / "wip-base.txt",
             )
             return False
+        if config.wip_scaffold and wip_scope.is_in_head(config.wip_scaffold):
+            logger.info(
+                "Resuming a --wip run — scaffolding commit %s is already in "
+                "place.",
+                config.wip_scaffold[:7],
+            )
+            return True
+        state = detect_state(config.log_dir, DEFAULT_COMMIT_PATTERN)
+        if state.status != "resumable":
+            # ``unwind`` leaves the metadata behind on a run that finished
+            # normally too, so a dangling SHA on its own does not mean there
+            # is work to pick up.  Re-parking here would sweep the tree into
+            # a scaffolding commit the loop immediately short-circuits past,
+            # and the unwind would then write an empty wip-fixes.diff over
+            # the finished run's one.
+            logger.info(
+                "Nothing to resume in %s (%s) — the working tree is left as "
+                "it is.",
+                config.log_dir,
+                state.prev_status or state.status,
+            )
+            return True
+        # The metadata outlives the scaffolding: every return path unwinds it,
+        # including soft failures like a fixer error, so a resumable run
+        # routinely starts with the work uncommitted again.  Trusting the
+        # metadata here would send the loop's resume reset straight at it and
+        # stash the very work this run is meant to review.  Park it again.
         logger.info(
-            "Resuming a --wip run — scaffolding commit %s is already in place.",
+            "Scaffolding commit %s is gone — a previous run unwound it. "
+            "Re-parking the working tree.",
             (config.wip_scaffold or "?")[:7],
         )
-        return True
+        previous_scaffold = config.wip_scaffold
+        reparking_from = config.wip_base
 
     dirty = wip_scope.uncommitted_files()
     if not dirty:
@@ -142,6 +188,17 @@ def _prepare_wip_scope(config: LoopConfig) -> bool:
             "--wip: the working tree is clean — there is no uncommitted "
             "work to review.",
         )
+        # A clean tree on the re-park path means the work is not in the
+        # working tree *or* in the recorded scaffolding: an earlier run was
+        # killed before it could unwind. The base is the way back.
+        if reparking_from and commit_scope.resolve_commit("HEAD") != reparking_from:
+            logger.error(
+                "HEAD has moved past the recorded base %s — an interrupted run "
+                "may have left the work in a commit of its own. Check the "
+                "history, then: git reset --mixed %s",
+                reparking_from[:7],
+                reparking_from,
+            )
         return False
     logger.info("WIP scope: %d uncommitted file(s).", len(dirty))
 
@@ -193,6 +250,21 @@ def _prepare_wip_scope(config: LoopConfig) -> bool:
         return False
     config.wip_base = head
     config.wip_scaffold = scaffold
+    # ``_save_metadata`` only runs on fresh runs, so on the re-park path this
+    # is the only chance to replace the now-dangling SHA on disk.  Without it a
+    # run killed before its unwind leaves the work in a commit nothing records.
+    wip_scope.save_metadata(config.log_dir, head, scaffold)
+    # Only now is wip-fixes.diff doomed: this run's ``unwind`` will overwrite
+    # it, and the previous attempt's fixes are not recoverable from it because
+    # re-parking folded them into the new scaffolding alongside the user's own
+    # work.  Every abort path above returns before this, so a run that does no
+    # work leaves the artefact where the README says it is.
+    if previous_scaffold:
+        previous_fixes = config.log_dir / "wip-fixes.diff"
+        if previous_fixes.is_file():
+            kept = config.log_dir / f"wip-fixes-{previous_scaffold[:7]}.diff"
+            previous_fixes.rename(kept)
+            logger.info("Previous attempt's fixes kept at %s", kept)
     logger.warning(
         "If this run is interrupted the scaffolding stays behind. Undo it with:"
         "\n  git reset --mixed %s",

--- a/src/mr_overkill/review_loop.py
+++ b/src/mr_overkill/review_loop.py
@@ -168,6 +168,12 @@ def _prepare_wip_scope(config: LoopConfig) -> bool:
                 config.log_dir,
                 state.prev_status or state.status,
             )
+            # The metadata stays as it is — the loop's resume check compares it
+            # against what is on disk — but there is nothing to tear down: the
+            # recorded scaffolding is already gone from HEAD (checked above), so
+            # an unwind could only no-op or refuse, and refusing would tell the
+            # user to reset away a commit this run never made.
+            config.wip_unwind = False
             return True
         # The metadata outlives the scaffolding: every return path unwinds it,
         # including soft failures like a fixer error, so a resumable run
@@ -275,7 +281,13 @@ def _prepare_wip_scope(config: LoopConfig) -> bool:
 
 def _unwind_wip_scope(config: LoopConfig) -> bool:
     """Remove the scaffolding, leaving the work uncommitted again."""
-    if not config.wip or not config.wip_base:
+    if not config.wip or not config.wip_base or not config.wip_unwind:
+        return True
+    # A run that may not commit never scaffolded, so nothing here belongs to
+    # it: ``--resume`` restores the recorded metadata regardless of the commit
+    # mode, and acting on it would refuse over — or reset away — a commit some
+    # other run made.
+    if not _wip_commits_allowed(config):
         return True
     if wip_scope.unwind(config.wip_base, config.wip_scaffold, config.log_dir):
         return True

--- a/src/mr_overkill/self_review.py
+++ b/src/mr_overkill/self_review.py
@@ -55,6 +55,7 @@ def self_review_subloop(
     budget_scope: BudgetScope = BudgetScope.MICRO,
     dry_run: bool = False,
     fix_nits: bool = False,
+    scope_note: str = "",
     original_review_json: dict[str, object] | None = None,
     cwd: Path | None = None,
 ) -> str:
@@ -82,6 +83,9 @@ def self_review_subloop(
         Scope for budget checks (default: micro).
     dry_run
         If True, review only — skip re-fix.
+    scope_note
+        Extra calibration appended to the guidelines, for runs where the diff
+        is not purely the fixer's work.
     original_review_json
         Parsed original review dict (for refactoring_plan injection).
     cwd
@@ -135,7 +139,7 @@ def self_review_subloop(
             )
             break
 
-        extra_guidelines = _FIX_NITS_GUIDELINES if fix_nits else ""
+        extra_guidelines = (_FIX_NITS_GUIDELINES if fix_nits else "") + scope_note
         prompt_vars = {
             "CURRENT_BRANCH": current_branch,
             "TARGET_BRANCH": target_branch,

--- a/src/mr_overkill/wip_scope.py
+++ b/src/mr_overkill/wip_scope.py
@@ -206,6 +206,18 @@ def create_scaffold_commit(cwd: Path | None = None) -> str | None:
     return sha or None
 
 
+def head_is_scaffold(cwd: Path | None = None) -> bool:
+    """Whether HEAD is itself a leftover scaffolding commit.
+
+    The subject is the only signal that survives a wiped log directory, so it
+    is what a fresh run has to go on: the metadata files are read back on
+    ``--resume`` alone, and a run interrupted before its unwind is exactly the
+    case that has to be caught here.
+    """
+    result = _run(["git", "log", "-1", "--format=%s"], cwd)
+    return result.returncode == 0 and result.stdout.strip() == SCAFFOLD_MESSAGE
+
+
 def is_in_head(commit: str, cwd: Path | None = None) -> bool:
     """Whether *commit* is an ancestor of HEAD (or HEAD itself)."""
     return _run(

--- a/src/mr_overkill/wip_scope.py
+++ b/src/mr_overkill/wip_scope.py
@@ -257,16 +257,36 @@ def create_scaffold_commit(cwd: Path | None = None) -> str | None:
     return sha or None
 
 
-def head_is_scaffold(cwd: Path | None = None) -> bool:
-    """Whether HEAD is itself a leftover scaffolding commit.
+#: How far back a fresh run looks for a leftover scaffolding commit.  Bounded
+#: so an ancient one nobody ever cleaned up cannot refuse every run forever.
+_SCAFFOLD_SEARCH_DEPTH = 25
+
+
+def find_scaffold_in_head(
+    cwd: Path | None = None, limit: int = _SCAFFOLD_SEARCH_DEPTH
+) -> str | None:
+    """SHA of the newest leftover scaffolding commit reachable from HEAD.
 
     The subject is the only signal that survives a wiped log directory, so it
     is what a fresh run has to go on: the metadata files are read back on
     ``--resume`` alone, and a run interrupted before its unwind is exactly the
     case that has to be caught here.
+
+    HEAD on its own is not enough to look at.  An interrupted run that got as
+    far as one fix commit leaves the scaffolding a commit *back*, and a fresh
+    run checking HEAD alone would scaffold on top of it and unwind only to that
+    fix commit — stranding both it and the earlier draft on the branch for
+    good.  The scaffolding is never pushed and always unwound, so anything
+    found here belongs to a run that died.
     """
-    result = _run(["git", "log", "-1", "--format=%s"], cwd)
-    return result.returncode == 0 and result.stdout.strip() == SCAFFOLD_MESSAGE
+    result = _run(["git", "log", f"-n{limit}", "--format=%H %s", "HEAD"], cwd)
+    if result.returncode != 0:
+        return None
+    for line in result.stdout.splitlines():
+        sha, _, subject = line.partition(" ")
+        if subject.strip() == SCAFFOLD_MESSAGE:
+            return sha.strip()
+    return None
 
 
 def is_in_head(commit: str, cwd: Path | None = None) -> bool:
@@ -274,6 +294,31 @@ def is_in_head(commit: str, cwd: Path | None = None) -> bool:
     return _run(
         ["git", "merge-base", "--is-ancestor", commit, "HEAD"], cwd
     ).returncode == 0
+
+
+def foreign_commits_since(
+    commit: str, fix_prefix: str, cwd: Path | None = None
+) -> list[str]:
+    """Subjects of commits after *commit* that this loop did not make.
+
+    Being on the branch the scaffolding was made on does not prove everything
+    stacked on it is the loop's: a user who commits normally on top of an
+    interrupted run and then resumes would have that commit reset back into
+    uncommitted changes by the unwind.  The loop's own commits all carry
+    *fix_prefix*, so anything else in the range is someone else's.
+
+    *commit* is expected to be in HEAD's history already — the caller checks
+    that with :func:`is_in_head` — so a git failure here means the range could
+    not be read, not that there is something in it.
+    """
+    result = _run(["git", "log", "--format=%s", f"{commit}..HEAD"], cwd)
+    if result.returncode != 0:
+        return []
+    return [
+        subject
+        for subject in (line.strip() for line in result.stdout.splitlines())
+        if subject and not subject.startswith(fix_prefix)
+    ]
 
 
 def save_metadata(log_dir: Path, base: str, scaffold: str | None) -> None:

--- a/src/mr_overkill/wip_scope.py
+++ b/src/mr_overkill/wip_scope.py
@@ -195,6 +195,26 @@ def create_scaffold_commit(cwd: Path | None = None) -> str | None:
     return sha or None
 
 
+def is_in_head(commit: str, cwd: Path | None = None) -> bool:
+    """Whether *commit* is an ancestor of HEAD (or HEAD itself)."""
+    return _run(
+        ["git", "merge-base", "--is-ancestor", commit, "HEAD"], cwd
+    ).returncode == 0
+
+
+def save_metadata(log_dir: Path, base: str, scaffold: str | None) -> None:
+    """Record where to unwind to, so a later ``--resume`` can find it.
+
+    An interrupted --wip run is only recoverable while these survive: they are
+    the sole record of where the scaffolding sits and what it was made on.  So
+    they are written as soon as the scaffolding exists rather than once per
+    run — a resume that re-parks the work replaces a SHA already dangling.
+    """
+    log_dir.mkdir(parents=True, exist_ok=True)
+    (log_dir / "wip-base.txt").write_text(base)
+    (log_dir / "wip-scaffold.txt").write_text(scaffold or "")
+
+
 def unwind(
     base: str,
     scaffold: str | None,
@@ -222,8 +242,7 @@ def unwind(
             "alone; check the history before resetting anything.",
         )
         return False
-    ancestry = _run(["git", "merge-base", "--is-ancestor", scaffold, "HEAD"], cwd)
-    if ancestry.returncode != 0:
+    if not is_in_head(scaffold, cwd):
         logger.error(
             "Cannot unwind: scaffolding commit %s is not in HEAD's history, so "
             "this is not the branch it was made on. HEAD is left alone.",
@@ -232,7 +251,10 @@ def unwind(
         return False
 
     result = _run(["git", "diff", scaffold, "HEAD"], cwd)
-    if result.returncode == 0:
+    # An empty diff means the loop committed nothing, so there is nothing to
+    # report — and writing it would replace an earlier attempt's artefact with
+    # a file that says the loop changed nothing.
+    if result.returncode == 0 and result.stdout.strip():
         log_dir.mkdir(parents=True, exist_ok=True)
         (log_dir / "wip-fixes.diff").write_text(result.stdout, encoding="utf-8")
 

--- a/src/mr_overkill/wip_scope.py
+++ b/src/mr_overkill/wip_scope.py
@@ -101,21 +101,18 @@ def merge_base(target: str, cwd: Path | None = None) -> str | None:
     return result.stdout.strip() or None
 
 
-def write_worktree_diff(target: str, output: Path, cwd: Path | None = None) -> int:
-    """Write the fork-point-to-working-tree diff to *output*; return byte count.
+def _worktree_diff(commit: str, cwd: Path | None = None) -> str | None:
+    """``git diff <commit>`` against the working tree; ``None`` if git failed.
 
-    Returns 0 when git fails or there is nothing to review; the caller is
-    expected to treat that as fatal rather than reviewing an empty patch.
+    ``git diff <commit>`` compares the commit against the *working tree*, which
+    is the whole point here: committed work and uncommitted edits land in one
+    patch.
 
     Untracked files are invisible to ``git diff``, so they are staged as
     intent-to-add first — the trick ``self_review._generate_diff`` uses.  Only
     the untracked paths are added and only those are reset afterwards, so a
     user's existing staged/unstaged split survives untouched.
     """
-    base = merge_base(target, cwd)
-    if base is None:
-        return 0
-
     untracked = _untracked_files(cwd)
     if untracked:
         _run(
@@ -124,21 +121,16 @@ def write_worktree_diff(target: str, output: Path, cwd: Path | None = None) -> i
             stdin="\n".join(untracked),
         )
     try:
-        # ``git diff <commit>`` compares the commit against the *working tree*,
-        # which is the whole point here: committed branch work and uncommitted
-        # edits land in one patch.
-        result = _run(["git", "diff", base], cwd)
+        result = _run(["git", "diff", commit], cwd)
         if result.returncode != 0:
             logger.error(
                 "git diff %s failed (exit %d): %s",
-                base,
+                commit,
                 result.returncode,
                 result.stderr.strip(),
             )
-            return 0
-        output.parent.mkdir(parents=True, exist_ok=True)
-        output.write_text(result.stdout, encoding="utf-8")
-        return len(result.stdout.encode("utf-8"))
+            return None
+        return result.stdout
     finally:
         if untracked:
             _run(
@@ -146,6 +138,23 @@ def write_worktree_diff(target: str, output: Path, cwd: Path | None = None) -> i
                 cwd,
                 stdin="\n".join(untracked),
             )
+
+
+def write_worktree_diff(target: str, output: Path, cwd: Path | None = None) -> int:
+    """Write the fork-point-to-working-tree diff to *output*; return byte count.
+
+    Returns 0 when git fails or there is nothing to review; the caller is
+    expected to treat that as fatal rather than reviewing an empty patch.
+    """
+    base = merge_base(target, cwd)
+    if base is None:
+        return 0
+    diff = _worktree_diff(base, cwd)
+    if diff is None:
+        return 0
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(diff, encoding="utf-8")
+    return len(diff.encode("utf-8"))
 
 
 def create_scaffold_commit(cwd: Path | None = None) -> str | None:
@@ -182,8 +191,17 @@ def create_scaffold_commit(cwd: Path | None = None) -> str | None:
     for f in files:
         logger.info("  %s", f)
 
+    # Same pathspec as the add: the index may already hold a log artefact the
+    # user staged themselves, and committing the whole index would put it in
+    # the scaffolding commit — and so in the branch diff the reviewer reads —
+    # despite being excluded from the scope above.  It stays staged, untouched.
     committed = _run(
-        ["git", "commit", "--no-verify", "--quiet", "-m", SCAFFOLD_MESSAGE], cwd
+        [
+            "git", "commit", "--no-verify", "--quiet",
+            "-m", SCAFFOLD_MESSAGE, "--pathspec-from-file=-",
+        ],
+        cwd,
+        stdin="\n".join(files),
     )
     if committed.returncode != 0:
         # "nothing to commit" — a dirty submodule whose gitlink did not move
@@ -243,6 +261,7 @@ def unwind(
     scaffold: str | None,
     log_dir: Path,
     cwd: Path | None = None,
+    branch: str | None = None,
 ) -> bool:
     """Tear the scaffolding down: back to *base* with the changes uncommitted.
 
@@ -272,14 +291,35 @@ def unwind(
             scaffold[:7],
         )
         return False
+    # Ancestry is not identity: the scaffolding commit is also in the history
+    # of anything branched off it.  *branch* is the branch the scaffolding was
+    # made on, so a mismatch here means the reset would rewind someone else's
+    # commits into uncommitted changes.
+    if branch:
+        current = _run(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd)
+        on = current.stdout.strip()
+        if current.returncode != 0 or on != branch:
+            logger.error(
+                "Cannot unwind: the scaffolding was made on '%s' but HEAD is "
+                "on '%s'. HEAD is left alone; switch back and undo it there: "
+                "git reset --mixed %s",
+                branch,
+                on or "(unknown)",
+                base,
+            )
+            return False
 
-    result = _run(["git", "diff", scaffold, "HEAD"], cwd)
-    # An empty diff means the loop committed nothing, so there is nothing to
+    # Diffed against the working tree, not HEAD: a fixer that edited files and
+    # then failed leaves HEAD at the scaffolding commit, and those edits are
+    # exactly what has to stay distinguishable from the user's own work once
+    # the reset below mixes the two.
+    fixes = _worktree_diff(scaffold, cwd)
+    # An empty diff means the loop changed nothing, so there is nothing to
     # report — and writing it would replace an earlier attempt's artefact with
     # a file that says the loop changed nothing.
-    if result.returncode == 0 and result.stdout.strip():
+    if fixes and fixes.strip():
         log_dir.mkdir(parents=True, exist_ok=True)
-        (log_dir / "wip-fixes.diff").write_text(result.stdout, encoding="utf-8")
+        (log_dir / "wip-fixes.diff").write_text(fixes, encoding="utf-8")
 
     reset = _run(["git", "reset", "--quiet", "--mixed", base], cwd)
     if reset.returncode != 0:

--- a/src/mr_overkill/wip_scope.py
+++ b/src/mr_overkill/wip_scope.py
@@ -60,6 +60,34 @@ def _untracked_files(cwd: Path | None = None) -> list[str]:
     ]
 
 
+# Files git drops in the git dir while a multi-step operation is unfinished.
+_IN_PROGRESS_MARKERS = {
+    "MERGE_HEAD": "merge",
+    "CHERRY_PICK_HEAD": "cherry-pick",
+    "REVERT_HEAD": "revert",
+    "rebase-merge": "rebase",
+    "rebase-apply": "rebase",
+}
+
+
+def operation_in_progress(cwd: Path | None = None) -> str | None:
+    """Name of an unfinished git operation, or ``None`` if the repo is idle.
+
+    Committing in the middle of one would conclude it: a scaffolding commit
+    made during a conflicted merge *is* the merge commit, and unwinding it
+    resets past the merge and drops ``MERGE_HEAD``, leaving no way to finish
+    what the author started.
+    """
+    result = _run(["git", "rev-parse", "--git-dir"], cwd)
+    if result.returncode != 0:
+        return None
+    git_dir = Path(cwd or ".") / result.stdout.strip()
+    for marker, name in _IN_PROGRESS_MARKERS.items():
+        if (git_dir / marker).exists():
+            return name
+    return None
+
+
 def merge_base(target: str, cwd: Path | None = None) -> str | None:
     """Fork point of *target* and HEAD, or ``None`` if they are unrelated."""
     result = _run(["git", "merge-base", target, "HEAD"], cwd)
@@ -180,29 +208,33 @@ def unwind(
     saved to ``wip-fixes.diff`` first, because once the scaffolding commit is
     gone there is no way left to tell the user's own work from the AI's edits.
     """
-    if scaffold:
-        result = _run(["git", "diff", scaffold, "HEAD"], cwd)
-        if result.returncode == 0:
-            log_dir.mkdir(parents=True, exist_ok=True)
-            (log_dir / "wip-fixes.diff").write_text(
-                result.stdout, encoding="utf-8"
-            )
-
     head = _run(["git", "rev-parse", "HEAD"], cwd)
     if head.stdout.strip() == base:
         return True
 
-    # Resetting to a commit HEAD does not descend from would move the branch
-    # somewhere it has never been.  Refuse rather than guess.
-    ancestry = _run(["git", "merge-base", "--is-ancestor", base, "HEAD"], cwd)
-    if ancestry.returncode != 0:
+    # ``base`` alone is not enough to prove this branch is the one that was
+    # scaffolded: a sibling branch off the same commit passes an ancestry test
+    # against it and would be silently rewound.  The scaffolding commit is
+    # unique to the run, so that is what has to be in HEAD's history.
+    if not scaffold:
         logger.error(
-            "Cannot unwind: %s is not an ancestor of HEAD. The scaffolding "
-            "commit is still in place — reset manually once you have checked "
-            "what happened.",
-            base[:7],
+            "Cannot unwind: no scaffolding commit was recorded. HEAD is left "
+            "alone; check the history before resetting anything.",
         )
         return False
+    ancestry = _run(["git", "merge-base", "--is-ancestor", scaffold, "HEAD"], cwd)
+    if ancestry.returncode != 0:
+        logger.error(
+            "Cannot unwind: scaffolding commit %s is not in HEAD's history, so "
+            "this is not the branch it was made on. HEAD is left alone.",
+            scaffold[:7],
+        )
+        return False
+
+    result = _run(["git", "diff", scaffold, "HEAD"], cwd)
+    if result.returncode == 0:
+        log_dir.mkdir(parents=True, exist_ok=True)
+        (log_dir / "wip-fixes.diff").write_text(result.stdout, encoding="utf-8")
 
     reset = _run(["git", "reset", "--quiet", "--mixed", base], cwd)
     if reset.returncode != 0:

--- a/src/mr_overkill/wip_scope.py
+++ b/src/mr_overkill/wip_scope.py
@@ -32,13 +32,6 @@ SCAFFOLD_MESSAGE = "wip: review-loop scaffolding [skip ci]"
 # ``git_ops.commit_and_push``'s ``exclude_prefixes``.
 _LOG_PREFIXES = (".overkill/logs/", ".review-loop/logs/")
 
-# ``:(top)`` anchors a pathspec at the repository root regardless of cwd.
-_ADD_PATHSPEC = [
-    ":(top)",
-    ":(exclude,top).overkill/logs",
-    ":(exclude,top).review-loop/logs",
-]
-
 
 def _run(
     cmd: list[str], cwd: Path | None = None, stdin: str | None = None
@@ -134,15 +127,26 @@ def create_scaffold_commit(cwd: Path | None = None) -> str | None:
     it will pass by the time it is finished, and a hook rejecting a commit that
     exists only to be torn down again would make the mode unusable.
     """
-    staged = _run(["git", "add", "-A", "--", *_ADD_PATHSPEC], cwd)
-    if staged.returncode != 0:
-        logger.error("git add failed: %s", staged.stderr.strip())
-        return None
-
-    listing = _run(["git", "diff", "--cached", "--name-only"], cwd)
-    files = [f for f in listing.stdout.splitlines() if f.strip()]
+    files = uncommitted_files(cwd)
     if not files:
         logger.error("Nothing to stage — no uncommitted work to scaffold.")
+        return None
+
+    # Stage the explicit list rather than ``git add -A`` with an
+    # ``:(exclude)`` pathspec: naming a gitignored path in a pathspec makes
+    # git abort the whole add — after it has already staged part of it —
+    # and the log directory is gitignored in plenty of repos.  ``-A`` still
+    # applies to the listed paths, so deletions are staged too.
+    staged = _run(
+        ["git", "add", "-A", "--pathspec-from-file=-"],
+        cwd,
+        stdin="\n".join(files),
+    )
+    if staged.returncode != 0:
+        logger.error(
+            "git add failed, and the index may be partially staged: %s",
+            staged.stderr.strip(),
+        )
         return None
     # ``git add -A`` sweeps in anything not covered by .gitignore, so show
     # exactly what is going into the commit.

--- a/src/mr_overkill/wip_scope.py
+++ b/src/mr_overkill/wip_scope.py
@@ -60,6 +60,29 @@ def _untracked_files(cwd: Path | None = None) -> list[str]:
     ]
 
 
+def _staged_deletions(cwd: Path | None = None) -> list[str]:
+    """Paths whose deletion is already staged, a rename's source included.
+
+    ``git diff --cached --name-only`` reports a rename as its destination
+    alone, so :func:`uncommitted_files` never sees the source: committing the
+    destination by itself leaves the source's deletion staged, the tree dirty,
+    and the loop's clean-tree check rejects the run.  ``--no-renames`` splits
+    the rename back into the delete half the scaffolding has to cover too.
+    """
+    result = _run(
+        [
+            "git", "diff", "--cached", "--name-only",
+            "--no-renames", "--diff-filter=D",
+        ],
+        cwd,
+    )
+    return [
+        f
+        for f in (line.strip() for line in result.stdout.splitlines())
+        if f and not any(f.startswith(p) for p in _LOG_PREFIXES)
+    ]
+
+
 # Files git drops in the git dir while a multi-step operation is unfinished.
 _IN_PROGRESS_MARKERS = {
     "MERGE_HEAD": "merge",
@@ -164,35 +187,45 @@ def create_scaffold_commit(cwd: Path | None = None) -> str | None:
     it will pass by the time it is finished, and a hook rejecting a commit that
     exists only to be torn down again would make the mode unusable.
     """
-    files = uncommitted_files(cwd)
+    deleted = set(_staged_deletions(cwd))
+    files = sorted(set(uncommitted_files(cwd)) | deleted)
     if not files:
         logger.error("Nothing to stage — no uncommitted work to scaffold.")
         return None
+
+    # ``git add`` matches its pathspec against the working tree and the index
+    # only, so naming a path that is in neither — a staged deletion, a staged
+    # rename's source — makes it abort the whole add.  Those paths are already
+    # staged as deleted, so they belong in the commit's pathspec, not here.
+    root = Path(cwd or ".")
+    to_add = [f for f in files if f not in deleted or (root / f).exists()]
 
     # Stage the explicit list rather than ``git add -A`` with an
     # ``:(exclude)`` pathspec: naming a gitignored path in a pathspec makes
     # git abort the whole add — after it has already staged part of it —
     # and the log directory is gitignored in plenty of repos.  ``-A`` still
     # applies to the listed paths, so deletions are staged too.
-    staged = _run(
-        ["git", "add", "-A", "--pathspec-from-file=-"],
-        cwd,
-        stdin="\n".join(files),
-    )
-    if staged.returncode != 0:
-        logger.error(
-            "git add failed, and the index may be partially staged: %s",
-            staged.stderr.strip(),
+    if to_add:
+        staged = _run(
+            ["git", "add", "-A", "--pathspec-from-file=-"],
+            cwd,
+            stdin="\n".join(to_add),
         )
-        return None
+        if staged.returncode != 0:
+            logger.error(
+                "git add failed, and the index may be partially staged: %s",
+                staged.stderr.strip(),
+            )
+            return None
+
     # ``git add -A`` sweeps in anything not covered by .gitignore, so show
     # exactly what is going into the commit.
     logger.info("Parking %d uncommitted file(s) in a scaffolding commit:", len(files))
     for f in files:
         logger.info("  %s", f)
 
-    # Same pathspec as the add: the index may already hold a log artefact the
-    # user staged themselves, and committing the whole index would put it in
+    # Pathspec-limited like the add: the index may already hold a log artefact
+    # the user staged themselves, and committing the whole index would put it in
     # the scaffolding commit — and so in the branch diff the reviewer reads —
     # despite being excluded from the scope above.  It stays staged, untouched.
     committed = _run(

--- a/src/mr_overkill/wip_scope.py
+++ b/src/mr_overkill/wip_scope.py
@@ -1,0 +1,212 @@
+"""WIP scope review: include uncommitted working-tree changes in the review.
+
+The normal review loop scopes itself with ``git diff <target>...<current>``,
+which only ever sees **committed** work.  This module supplies the two
+mechanisms that let uncommitted work be reviewed instead, picked by whether
+the run is allowed to commit (see ``review_loop._prepare_wip_scope``):
+
+*No-commit runs* (``--dry-run`` / ``--no-auto-commit``) get
+:func:`write_worktree_diff`, a scope artefact handed to the reviewer the same
+way ``commit_scope`` hands over a historical commit's patch.
+
+*Committing runs* get :func:`create_scaffold_commit`, which parks the
+uncommitted work in a throwaway commit so the loop's convergence machinery —
+all of which reads the commit graph — runs completely unchanged.  The
+scaffolding is torn down by :func:`unwind` when the loop finishes, leaving
+zero new commits behind and the working tree dirty again.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+
+from mr_overkill.git_ops import git_all_dirty
+
+logger = logging.getLogger(__name__)
+
+SCAFFOLD_MESSAGE = "wip: review-loop scaffolding [skip ci]"
+
+# Log artefacts are not part of anyone's work in progress.  Same list as
+# ``git_ops.commit_and_push``'s ``exclude_prefixes``.
+_LOG_PREFIXES = (".overkill/logs/", ".review-loop/logs/")
+
+# ``:(top)`` anchors a pathspec at the repository root regardless of cwd.
+_ADD_PATHSPEC = [
+    ":(top)",
+    ":(exclude,top).overkill/logs",
+    ":(exclude,top).review-loop/logs",
+]
+
+
+def _run(
+    cmd: list[str], cwd: Path | None = None, stdin: str | None = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd, cwd=cwd, input=stdin, capture_output=True, text=True, check=False
+    )
+
+
+def uncommitted_files(cwd: Path | None = None) -> list[str]:
+    """Dirty and untracked files that count as work in progress."""
+    return [
+        f
+        for f in git_all_dirty(cwd)
+        if not any(f.startswith(p) for p in _LOG_PREFIXES)
+    ]
+
+
+def _untracked_files(cwd: Path | None = None) -> list[str]:
+    """Untracked, non-ignored files, excluding log artefacts."""
+    result = _run(["git", "ls-files", "--others", "--exclude-standard"], cwd)
+    return [
+        f
+        for f in (line.strip() for line in result.stdout.splitlines())
+        if f and not any(f.startswith(p) for p in _LOG_PREFIXES)
+    ]
+
+
+def merge_base(target: str, cwd: Path | None = None) -> str | None:
+    """Fork point of *target* and HEAD, or ``None`` if they are unrelated."""
+    result = _run(["git", "merge-base", target, "HEAD"], cwd)
+    if result.returncode != 0:
+        logger.error(
+            "No merge base between '%s' and HEAD: %s",
+            target,
+            result.stderr.strip(),
+        )
+        return None
+    return result.stdout.strip() or None
+
+
+def write_worktree_diff(target: str, output: Path, cwd: Path | None = None) -> int:
+    """Write the fork-point-to-working-tree diff to *output*; return byte count.
+
+    Returns 0 when git fails or there is nothing to review; the caller is
+    expected to treat that as fatal rather than reviewing an empty patch.
+
+    Untracked files are invisible to ``git diff``, so they are staged as
+    intent-to-add first — the trick ``self_review._generate_diff`` uses.  Only
+    the untracked paths are added and only those are reset afterwards, so a
+    user's existing staged/unstaged split survives untouched.
+    """
+    base = merge_base(target, cwd)
+    if base is None:
+        return 0
+
+    untracked = _untracked_files(cwd)
+    if untracked:
+        _run(
+            ["git", "add", "--intent-to-add", "--pathspec-from-file=-"],
+            cwd,
+            stdin="\n".join(untracked),
+        )
+    try:
+        # ``git diff <commit>`` compares the commit against the *working tree*,
+        # which is the whole point here: committed branch work and uncommitted
+        # edits land in one patch.
+        result = _run(["git", "diff", base], cwd)
+        if result.returncode != 0:
+            logger.error(
+                "git diff %s failed (exit %d): %s",
+                base,
+                result.returncode,
+                result.stderr.strip(),
+            )
+            return 0
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(result.stdout, encoding="utf-8")
+        return len(result.stdout.encode("utf-8"))
+    finally:
+        if untracked:
+            _run(
+                ["git", "reset", "--quiet", "--pathspec-from-file=-"],
+                cwd,
+                stdin="\n".join(untracked),
+            )
+
+
+def create_scaffold_commit(cwd: Path | None = None) -> str | None:
+    """Commit every uncommitted change as a throwaway commit; return its SHA.
+
+    ``--no-verify`` is deliberate: work in progress routinely fails the hooks
+    it will pass by the time it is finished, and a hook rejecting a commit that
+    exists only to be torn down again would make the mode unusable.
+    """
+    staged = _run(["git", "add", "-A", "--", *_ADD_PATHSPEC], cwd)
+    if staged.returncode != 0:
+        logger.error("git add failed: %s", staged.stderr.strip())
+        return None
+
+    listing = _run(["git", "diff", "--cached", "--name-only"], cwd)
+    files = [f for f in listing.stdout.splitlines() if f.strip()]
+    if not files:
+        logger.error("Nothing to stage — no uncommitted work to scaffold.")
+        return None
+    # ``git add -A`` sweeps in anything not covered by .gitignore, so show
+    # exactly what is going into the commit.
+    logger.info("Parking %d uncommitted file(s) in a scaffolding commit:", len(files))
+    for f in files:
+        logger.info("  %s", f)
+
+    committed = _run(
+        ["git", "commit", "--no-verify", "--quiet", "-m", SCAFFOLD_MESSAGE], cwd
+    )
+    if committed.returncode != 0:
+        logger.error("Scaffolding commit failed: %s", committed.stderr.strip())
+        return None
+
+    head = _run(["git", "rev-parse", "HEAD"], cwd)
+    sha = head.stdout.strip()
+    logger.info("Scaffolding commit: %s", sha[:7])
+    return sha or None
+
+
+def unwind(
+    base: str,
+    scaffold: str | None,
+    log_dir: Path,
+    cwd: Path | None = None,
+) -> bool:
+    """Tear the scaffolding down: back to *base* with the changes uncommitted.
+
+    ``git reset --mixed`` never touches file contents, so the fixes stay in the
+    working tree — only the commits disappear.  The net change the loop made is
+    saved to ``wip-fixes.diff`` first, because once the scaffolding commit is
+    gone there is no way left to tell the user's own work from the AI's edits.
+    """
+    if scaffold:
+        result = _run(["git", "diff", scaffold, "HEAD"], cwd)
+        if result.returncode == 0:
+            log_dir.mkdir(parents=True, exist_ok=True)
+            (log_dir / "wip-fixes.diff").write_text(
+                result.stdout, encoding="utf-8"
+            )
+
+    head = _run(["git", "rev-parse", "HEAD"], cwd)
+    if head.stdout.strip() == base:
+        return True
+
+    # Resetting to a commit HEAD does not descend from would move the branch
+    # somewhere it has never been.  Refuse rather than guess.
+    ancestry = _run(["git", "merge-base", "--is-ancestor", base, "HEAD"], cwd)
+    if ancestry.returncode != 0:
+        logger.error(
+            "Cannot unwind: %s is not an ancestor of HEAD. The scaffolding "
+            "commit is still in place — reset manually once you have checked "
+            "what happened.",
+            base[:7],
+        )
+        return False
+
+    reset = _run(["git", "reset", "--quiet", "--mixed", base], cwd)
+    if reset.returncode != 0:
+        logger.error(
+            "git reset --mixed %s failed: %s", base[:7], reset.stderr.strip()
+        )
+        return False
+    logger.info(
+        "Scaffolding removed — back at %s with the changes uncommitted.", base[:7]
+    )
+    return True

--- a/src/mr_overkill/wip_scope.py
+++ b/src/mr_overkill/wip_scope.py
@@ -186,7 +186,18 @@ def create_scaffold_commit(cwd: Path | None = None) -> str | None:
         ["git", "commit", "--no-verify", "--quiet", "-m", SCAFFOLD_MESSAGE], cwd
     )
     if committed.returncode != 0:
-        logger.error("Scaffolding commit failed: %s", committed.stderr.strip())
+        # "nothing to commit" — a dirty submodule whose gitlink did not move
+        # stages nothing — is explained on stdout, not stderr.
+        detail = (
+            committed.stderr.strip()
+            or committed.stdout.strip()
+            or f"exit {committed.returncode}"
+        )
+        logger.error(
+            "Scaffolding commit failed, and anything it staged is left in "
+            "the index (file contents are untouched): %s",
+            detail,
+        )
         return None
 
     head = _run(["git", "rev-parse", "HEAD"], cwd)

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from mr_overkill import wip_scope
 from mr_overkill.agents import (
     ClaudeFixAgent,
     ClaudeRefactorReviewAgent,
@@ -746,3 +747,88 @@ class TestReviewScopeNote:
         for backend in ("codex", "claude", "gemini"):
             text = (root / f"{backend}-review.prompt.md").read_text()
             assert "${REVIEW_SCOPE_NOTE}" in text, backend
+
+
+class TestWipScopeNote:
+    """`--wip` reuses `${REVIEW_SCOPE_NOTE}`; the block it injects differs by
+    mechanism because the branch diff means something different in each."""
+
+    def _prompt(self, tmp_path: Path, marker: bool = True) -> Path:
+        p = tmp_path / "codex-review.prompt.md"
+        note = "${REVIEW_SCOPE_NOTE}\n" if marker else ""
+        p.write_text(
+            "You are a code reviewer analyzing a proposed change.\n"
+            f"{note}"
+            "## Context\n\n"
+            "- Current: ${CURRENT_BRANCH}\n- Target: ${TARGET_BRANCH}\n"
+            "- Iteration: ${ITERATION}\n${REVIEWER_CONTEXT}\n"
+        )
+        return p
+
+    def test_no_commit_mode_points_at_the_artefact(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        diff = tmp_path / "logs" / "wip.diff"
+        config = make_loop_config(wip=True, dry_run=True, scope_diff_file=diff)
+
+        note = _format_review_scope(config, 1)
+
+        assert "REVIEW MODE: UNCOMMITTED WORK" in note
+        assert str(diff) in note
+        # The branch diff shows only committed work here, so following it
+        # would skip the very thing under review.
+        assert "Ignore the `git diff` command" in note
+
+    def test_scaffold_mode_explains_the_throwaway_commit(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        config = make_loop_config(wip=True, wip_base="b" * 40)
+
+        note = _format_review_scope(config, 1)
+
+        assert "REVIEW MODE: UNCOMMITTED WORK" in note
+        assert wip_scope.SCAFFOLD_MESSAGE in note
+        assert "Ignore the `git diff` command" not in note
+
+    def test_draft_calibration_is_in_both(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        for config in (
+            make_loop_config(wip=True, dry_run=True,
+                             scope_diff_file=tmp_path / "wip.diff"),
+            make_loop_config(wip=True),
+        ):
+            assert "This work is unfinished" in _format_review_scope(config, 1)
+
+    def test_note_is_injected_into_the_prompt(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        config = make_loop_config(wip=True)
+        rendered = _render_review_prompt(self._prompt(tmp_path), config, 1)
+        assert rendered is not None
+        assert "REVIEW MODE: UNCOMMITTED WORK" in rendered
+
+    def test_stale_prompt_is_refused(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        # Without the marker the note vanishes silently and the reviewer
+        # inspects the wrong diff — which reads as "no findings".
+        config = make_loop_config(wip=True)
+        prompt = self._prompt(tmp_path, marker=False)
+        assert _render_review_prompt(prompt, config, 1) is None
+
+    def test_commit_scope_still_wins(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        # The CLI rejects the combination, but the note builder must not
+        # silently produce a hybrid if it ever slips through.
+        config = make_loop_config(
+            wip=True, scope_commit="a" * 40, scope_diff_file=tmp_path / "s.diff"
+        )
+        with (
+            patch("mr_overkill.commit_scope.commit_headline", return_value="x"),
+            patch("mr_overkill.commit_scope.is_ancestor_of_head", return_value=True),
+        ):
+            note = _format_review_scope(config, 1)
+        assert "REVIEW MODE: COMMIT SCOPE" in note
+        assert "REVIEW MODE: UNCOMMITTED WORK" not in note

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -444,6 +444,59 @@ class TestClaudeSelfReviewAgent:
         assert result == "sub-1: ok"
         mock_subloop.assert_called_once()
 
+    @patch("mr_overkill.agents._make_budget_fn")
+    @patch("mr_overkill.agents._make_retry_fn")
+    @patch(
+        "mr_overkill.agents.self_review_subloop",
+        return_value="sub-1: ok",
+    )
+    def test_no_commit_wip_run_calibrates_the_self_reviewer(
+        self,
+        mock_subloop: MagicMock,
+        mock_retry_factory: MagicMock,
+        mock_budget_factory: MagicMock,
+        tmp_path: Path,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        # Nothing is committed there, so the self-review diff carries the
+        # author's draft as well as the fix and the self-reviewer has to be
+        # told — otherwise the re-fix "reverts" the draft as scope creep.
+        mock_retry_factory.return_value = MagicMock()
+        mock_budget_factory.return_value = MagicMock()
+        review_json = json.dumps({"findings": []})
+
+        for config, expected in (
+            (
+                make_loop_config(
+                    wip=True, auto_commit=False,
+                    scope_diff_file=tmp_path / "wip.diff",
+                ),
+                True,
+            ),
+            (make_loop_config(wip=True), False),
+            # --commit sets scope_diff_file too, but HEAD is a real commit
+            # there, so the note's premise would be false.
+            (
+                make_loop_config(
+                    scope_commit="a" * 40,
+                    scope_diff_file=tmp_path / "scope.diff",
+                ),
+                False,
+            ),
+            (make_loop_config(), False),
+        ):
+            # ``call_args`` is the *last* call, so without this an early
+            # return would re-assert the previous config's kwargs.
+            mock_subloop.reset_mock()
+            fixer: FixAgent = MagicMock(spec=ClaudeFixAgent)
+            ClaudeSelfReviewAgent(config, fixer)([], 2, tmp_path, 1, review_json)
+
+            mock_subloop.assert_called_once()
+            note = mock_subloop.call_args.kwargs["scope_note"]
+            assert bool(note) is expected
+            if expected:
+                assert "uncommitted draft" in note
+
 
 # ── _BudgetFn ────────────────────────────────────────────────────────
 
@@ -779,6 +832,23 @@ class TestWipScopeNote:
         # would skip the very thing under review.
         assert "Ignore the `git diff` command" in note
 
+    def test_no_commit_mode_excludes_committed_work_from_the_draft_allowance(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        # The artefact is a fork-point-to-worktree diff, so the author's own
+        # commits on this branch are in it too — handing them the draft
+        # allowance would pass over half-written code committed days ago.
+        config = make_loop_config(
+            wip=True, dry_run=True, scope_diff_file=tmp_path / "wip.diff"
+        )
+
+        note = _format_review_scope(config, 1)
+
+        assert "commits the author already made here" in note
+        assert "git diff develop...HEAD" in note
+        assert "draft allowance below does not apply" in note
+        assert "The uncommitted part of the change under review" in note
+
     def test_scaffold_mode_explains_the_throwaway_commit(
         self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
     ) -> None:
@@ -789,6 +859,19 @@ class TestWipScopeNote:
         assert "REVIEW MODE: UNCOMMITTED WORK" in note
         assert wip_scope.SCAFFOLD_MESSAGE in note
         assert "Ignore the `git diff` command" not in note
+
+    def test_scaffold_mode_places_the_commit_in_the_branch(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        # The scaffolding is committed on top of whatever the author already
+        # committed on the branch, so calling it the branch's first commit
+        # points the reviewer at the wrong one — and hands the draft allowance
+        # to committed work that should be judged as finished.
+        note = _format_review_scope(make_loop_config(wip=True, wip_base="b" * 40), 1)
+
+        assert "first commit" not in note
+        assert "the author's own committed work on this branch" in note
+        assert "draft allowance below does not apply to them" in note
 
     def test_draft_calibration_is_in_both(
         self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -915,5 +915,13 @@ class TestWipArgs:
         config = self._parse(["-n", "1", "--wip", "--dry-run", "-t", "develop"])
         assert config.target_branch == "develop"
 
+    def test_resume_without_commits_is_refused(self) -> None:
+        # There is no scaffolding to resume, and the loop's resume reset
+        # would stash away the very working tree under review.
+        with pytest.raises(SystemExit):
+            self._parse(["-n", "1", "--wip", "--no-auto-commit", "--resume"])
+        with pytest.raises(SystemExit):
+            self._parse(["-n", "1", "--wip", "--dry-run", "--resume"])
+
     def test_normal_run_still_pushes(self) -> None:
         assert self._parse(["-n", "2"]).push_branch is True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -856,3 +856,64 @@ class TestCommitScopeResume:
         (log_dir / "scope-commit.txt").write_text(self.SHA)
         with pytest.raises(SystemExit):
             self._parse(["--resume", "-t", "develop"], tmp_path)
+
+
+class TestWipArgs:
+    """`--wip` wiring: one flag, and the safety rails that come with it."""
+
+    HEAD = "b" * 40
+
+    def _parse(
+        self, argv: list[str], rc: dict[str, str] | None = None
+    ) -> LoopConfig:
+        with (
+            patch("mr_overkill.cli._detect_pr_number", return_value="42"),
+            patch("mr_overkill.cli._detect_current_branch", return_value="feat/x"),
+            patch("mr_overkill.cli._load_rc_file", return_value=rc or {}),
+            patch(
+                "mr_overkill.cli.subprocess.run",
+                return_value=MagicMock(returncode=0, stdout="/tmp/repo"),
+            ),
+            patch("mr_overkill.cli.resolve_commit", return_value=self.HEAD),
+        ):
+            return parse_review_loop_args(argv)
+
+    def test_flag_sets_the_mode(self) -> None:
+        config = self._parse(["-n", "2", "--wip"])
+        assert config.wip is True
+
+    def test_absent_by_default(self) -> None:
+        assert self._parse(["-n", "2"]).wip is False
+
+    def test_rejects_combination_with_commit_scope(self) -> None:
+        with pytest.raises(SystemExit):
+            self._parse(["-n", "2", "--wip", "--commit", "abc123"])
+
+    def test_never_pushes(self) -> None:
+        # Pushing would publish unfinished work, and the scaffolding commit
+        # holding it, to a shared branch.
+        assert self._parse(["-n", "2", "--wip"]).push_branch is False
+
+    def test_push_stays_off_even_when_the_rc_asks_for_it(self) -> None:
+        config = self._parse(
+            ["-n", "2", "--wip", "--push"], rc={"COMMIT_SCOPE_PUSH": "true"}
+        )
+        assert config.push_branch is False
+
+    def test_no_pr_comments(self) -> None:
+        # The findings describe code that is in no PR.
+        assert self._parse(["-n", "2", "--wip"]).pr_number is None
+
+    def test_target_is_pinned_before_the_scaffold_moves_head(self) -> None:
+        # A target resolved after the scaffolding commit would name the
+        # scaffolding commit itself, and the diff would come out empty.
+        assert self._parse(["-n", "2", "--wip", "-t", "HEAD"]).target_branch == (
+            self.HEAD
+        )
+
+    def test_target_is_left_alone_without_commits(self) -> None:
+        config = self._parse(["-n", "1", "--wip", "--dry-run", "-t", "develop"])
+        assert config.target_branch == "develop"
+
+    def test_normal_run_still_pushes(self) -> None:
+        assert self._parse(["-n", "2"]).push_branch is True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -857,6 +857,17 @@ class TestCommitScopeResume:
         with pytest.raises(SystemExit):
             self._parse(["--resume", "-t", "develop"], tmp_path)
 
+    def test_rejects_wip(self, tmp_path: Path) -> None:
+        """The up-front --commit/--wip check never sees a restored scope, so
+        the combination would take the commit-scope path and send a
+        --no-auto-commit resume into the loop's working-tree reset."""
+        log_dir = self._log_dir(tmp_path)
+        (log_dir / "scope-commit.txt").write_text(self.SHA)
+        with pytest.raises(SystemExit):
+            self._parse(["--resume", "--wip"], tmp_path)
+        with pytest.raises(SystemExit):
+            self._parse(["--resume", "--wip", "--no-auto-commit"], tmp_path)
+
 
 class TestWipArgs:
     """`--wip` wiring: one flag, and the safety rails that come with it."""

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -6,6 +6,8 @@ import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from mr_overkill.git_ops import (
     changed_files_since_snapshot,
     commit_and_push,
@@ -265,3 +267,33 @@ class TestCommitAndPushPushFlag:
         ) is True
         assert self._head_of(remote) != remote_before
         assert self._head_of(remote) == self._head_of(tmp_git_repo)
+
+
+class TestCommitAndPushNoVerify:
+    """WIP commits carry unfinished work, so the hooks that would reject it
+    have to be skipped — and only there."""
+
+    def _repo_with_failing_hook(self, repo: Path) -> None:
+        hook = repo / ".git" / "hooks" / "pre-commit"
+        hook.write_text("#!/bin/sh\nexit 1\n")
+        hook.chmod(0o755)
+
+    def test_hooks_block_a_normal_commit(self, tmp_git_repo: Path) -> None:
+        self._repo_with_failing_hook(tmp_git_repo)
+        (tmp_git_repo / "a.py").write_text("a = 1\n")
+
+        with pytest.raises(RuntimeError):
+            commit_and_push([], "test: a", push=False, cwd=tmp_git_repo)
+
+    def test_no_verify_gets_the_commit_through(self, tmp_git_repo: Path) -> None:
+        self._repo_with_failing_hook(tmp_git_repo)
+        (tmp_git_repo / "a.py").write_text("a = 1\n")
+
+        assert commit_and_push(
+            [], "test: a", push=False, no_verify=True, cwd=tmp_git_repo
+        )
+        log = subprocess.run(
+            ["git", "log", "-1", "--format=%s"],
+            cwd=tmp_git_repo, capture_output=True, text=True, check=True,
+        )
+        assert log.stdout.strip() == "test: a"

--- a/tests/test_loop_engine.py
+++ b/tests/test_loop_engine.py
@@ -740,6 +740,15 @@ class TestCommitScopeNoFixOutcome:
         )
         assert self._run(config, tmp_path) == FinalStatus.FINDINGS_UNFIXED
 
+    def test_wip_reports_findings_unfixed_on_final_iteration(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        """A --wip target is pinned before the scaffolding commit, so the
+        branch diff always holds the parked work and the no-diff check can
+        never catch the no-op fixer — the commit site has to."""
+        config = make_loop_config(max_loop=1, log_dir=tmp_path, wip=True)
+        assert self._run(config, tmp_path) == FinalStatus.FINDINGS_UNFIXED
+
     def test_normal_mode_still_reports_claude_error(
         self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
     ) -> None:

--- a/tests/test_loop_engine.py
+++ b/tests/test_loop_engine.py
@@ -753,3 +753,98 @@ class TestCommitScopeNoFixOutcome:
         tree, so a branch run keeps its existing exhausted-loop outcome."""
         config = make_loop_config(max_loop=1, log_dir=tmp_path)
         assert self._run(config, tmp_path) == FinalStatus.MAX_ITERATIONS_REACHED
+
+
+class TestWipDirtyWorktreeGate:
+    """The clean-tree check exists to keep user WIP out of AI fix commits.
+    A --wip run that makes no commits has nothing to keep it out of."""
+
+    def _run(self, config: LoopConfig, tmp_path: Path) -> FinalStatus:
+        clean = {"findings": [], "overall_correctness": "patch is correct"}
+        with (
+            patch(
+                "mr_overkill.loop_engine._reject_dirty_worktree",
+                return_value=["src/wip.py"],
+            ),
+            patch("mr_overkill.loop_engine._validate_target_branch", return_value=True),
+            patch("mr_overkill.loop_engine._save_metadata"),
+            patch("mr_overkill.loop_engine._no_diff", return_value=False),
+        ):
+            result = review_fix_loop(
+                config,
+                reviewer=_mock_reviewer([clean]),
+                fixer=MagicMock(return_value=True),
+                cwd=tmp_path,
+            )
+        return result.final_status
+
+    def test_dirty_tree_is_allowed_without_commits(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        config = make_loop_config(
+            log_dir=tmp_path, wip=True, auto_commit=False,
+        )
+        assert self._run(config, tmp_path) == FinalStatus.ALL_CLEAR
+
+    def test_dirty_tree_still_rejected_when_wip_commits(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        """The scaffolding commit runs first, so reaching this check with a
+        dirty tree means something else is uncommitted — still a refusal."""
+        config = make_loop_config(log_dir=tmp_path, wip=True)
+        assert self._run(config, tmp_path) == FinalStatus.REVIEW_FAILED
+
+    def test_dirty_tree_still_rejected_without_wip(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        config = make_loop_config(log_dir=tmp_path, auto_commit=False)
+        assert self._run(config, tmp_path) == FinalStatus.REVIEW_FAILED
+
+
+class TestSaveMetadataWip:
+    def test_records_the_unwind_target(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        # An interrupted run is only recoverable while this survives.
+        config = make_loop_config(
+            log_dir=tmp_path, wip=True, wip_base="b" * 40, wip_scaffold="c" * 40
+        )
+        _save_metadata(config, tmp_path)
+        assert (tmp_path / "wip-base.txt").read_text() == "b" * 40
+        assert (tmp_path / "wip-scaffold.txt").read_text() == "c" * 40
+
+    def test_omits_when_nothing_was_scaffolded(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        config = make_loop_config(log_dir=tmp_path, wip=True, dry_run=True)
+        _save_metadata(config, tmp_path)
+        assert not (tmp_path / "wip-base.txt").exists()
+
+    def test_clears_a_stale_marker(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        (tmp_path / "wip-base.txt").write_text("b" * 40)
+        _save_metadata(make_loop_config(log_dir=tmp_path), tmp_path)
+        assert not (tmp_path / "wip-base.txt").exists()
+
+
+class TestWipResumeGuard:
+    def test_resume_without_the_recorded_base_is_refused(
+        self, tmp_path: Path, make_loop_config: Callable[..., LoopConfig]
+    ) -> None:
+        (tmp_path / "branch.txt").write_text("feat/test")
+        (tmp_path / "wip-base.txt").write_text("b" * 40)
+        config = make_loop_config(log_dir=tmp_path, resume=True, wip=True)
+        with patch(
+            "mr_overkill.loop_engine.detect_state",
+            return_value=ResumeState(
+                status="resumable", resume_from=2, reuse_review=False
+            ),
+        ):
+            result = review_fix_loop(
+                config,
+                reviewer=MagicMock(return_value=True),
+                fixer=MagicMock(return_value=True),
+                cwd=tmp_path,
+            )
+        assert result.final_status == FinalStatus.REVIEW_FAILED

--- a/tests/test_review_loop.py
+++ b/tests/test_review_loop.py
@@ -745,6 +745,11 @@ class TestPrepareWipScope:
         assert (config.log_dir / "wip-fixes.diff").read_text() == (
             "--- the finished run\n"
         )
+        # The metadata has to survive for loop_engine's resume check, so the
+        # unwind is disarmed instead: the recorded scaffolding is already gone
+        # from HEAD, and if the user has since committed their work an unwind
+        # would fail the run and point them at a reset that drops that commit.
+        assert config.wip_unwind is False
 
     @patch("mr_overkill.review_loop.commit_scope.resolve_commit")
     @patch("mr_overkill.review_loop.wip_scope")
@@ -880,6 +885,55 @@ class TestWipUnwind:
         config = make_loop_config(wip=True, wip_base="b" * 40, wip_scaffold="c" * 40)
 
         assert run(config) == 1
+
+    @patch("mr_overkill.review_loop.wip_scope")
+    @patch("mr_overkill.review_loop.review_fix_loop")
+    @patch("mr_overkill.review_loop._prepare_wip_scope", return_value=True)
+    def test_nothing_to_unwind_when_this_run_scaffolded_nothing(
+        self,
+        mock_prep: MagicMock,
+        mock_loop: MagicMock,
+        mock_ws: MagicMock,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        # A --wip --resume that found nothing to resume keeps the recorded base
+        # for the resume check but made no scaffolding of its own.
+        mock_loop.return_value = LoopResult(
+            final_status=FinalStatus.ALL_CLEAR, iterations_run=0
+        )
+        config = make_loop_config(
+            wip=True, wip_base="b" * 40, wip_scaffold="c" * 40, wip_unwind=False
+        )
+
+        assert run(config) == 0
+        mock_ws.unwind.assert_not_called()
+
+    @patch("mr_overkill.review_loop.wip_scope")
+    @patch("mr_overkill.review_loop.review_fix_loop")
+    @patch("mr_overkill.review_loop._prepare_wip_scope", return_value=True)
+    def test_nothing_to_unwind_when_the_run_may_not_commit(
+        self,
+        mock_prep: MagicMock,
+        mock_loop: MagicMock,
+        mock_ws: MagicMock,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        # --resume restores wip-base.txt whatever the commit mode, so a dry run
+        # starts with another run's metadata. Unwinding it would refuse over —
+        # or reset away — a commit this run never made.
+        mock_loop.return_value = LoopResult(
+            final_status=FinalStatus.DRY_RUN, iterations_run=1
+        )
+        config = make_loop_config(
+            wip=True,
+            resume=True,
+            dry_run=True,
+            wip_base="b" * 40,
+            wip_scaffold="c" * 40,
+        )
+
+        assert run(config) == 0
+        mock_ws.unwind.assert_not_called()
 
     @patch("mr_overkill.review_loop.wip_scope")
     @patch("mr_overkill.review_loop.review_fix_loop")

--- a/tests/test_review_loop.py
+++ b/tests/test_review_loop.py
@@ -550,6 +550,7 @@ class TestPrepareWipScope:
     ) -> None:
         mock_ws.uncommitted_files.return_value = ["a.py"]
         mock_ws.operation_in_progress.return_value = None
+        mock_ws.head_is_scaffold.return_value = False
         mock_resolve.return_value = "b" * 40
         mock_ws.create_scaffold_commit.return_value = "c" * 40
         config = self._config(make_loop_config, tmp_path)
@@ -616,6 +617,60 @@ class TestPrepareWipScope:
         )
         assert _prepare_wip_scope(config) is True
         mock_ws.create_scaffold_commit.assert_not_called()
+
+    @patch("mr_overkill.review_loop.commit_scope.resolve_commit")
+    @patch("mr_overkill.review_loop.wip_scope")
+    def test_fresh_run_refuses_to_nest_on_leftover_scaffolding(
+        self,
+        mock_ws: MagicMock,
+        mock_resolve: MagicMock,
+        tmp_path: Path,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        # A run killed before its unwind leaves the scaffolding in HEAD, and a
+        # fresh run reads no metadata back.  Scaffolding on top of it would make
+        # the leftover commit this run's base, overwrite wip-base.txt with it,
+        # and unwind only as far as it — stranding the earlier draft in a commit
+        # on the branch while the loop reports the tree merely dirty.
+        mock_ws.uncommitted_files.return_value = ["a.py"]
+        mock_ws.operation_in_progress.return_value = None
+        mock_ws.head_is_scaffold.return_value = True
+        mock_resolve.return_value = "b" * 40
+        config = self._config(make_loop_config, tmp_path)
+
+        assert _prepare_wip_scope(config) is False
+        mock_ws.create_scaffold_commit.assert_not_called()
+        mock_ws.save_metadata.assert_not_called()
+
+    @patch("mr_overkill.review_loop.commit_scope.resolve_commit")
+    @patch("mr_overkill.review_loop.wip_scope")
+    def test_resume_may_repark_onto_leftover_scaffolding(
+        self,
+        mock_ws: MagicMock,
+        mock_resolve: MagicMock,
+        tmp_path: Path,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        # The refusal above is what --resume is pointed at, so it must not fire
+        # here: a leftover scaffolding commit is exactly what the re-park path
+        # legitimately builds on once it has proved HEAD is the recorded base.
+        mock_ws.is_in_head.return_value = False
+        mock_ws.uncommitted_files.return_value = ["a.py"]
+        mock_ws.operation_in_progress.return_value = None
+        mock_ws.head_is_scaffold.return_value = True
+        mock_resolve.return_value = "b" * 40
+        mock_ws.create_scaffold_commit.return_value = "d" * 40
+        config = self._config(
+            make_loop_config,
+            tmp_path,
+            resume=True,
+            wip_base="b" * 40,
+            wip_scaffold="c" * 40,
+        )
+        self._resumable_logs(config)
+
+        assert _prepare_wip_scope(config) is True
+        mock_ws.create_scaffold_commit.assert_called_once()
 
     @patch("mr_overkill.review_loop.commit_scope.resolve_commit")
     @patch("mr_overkill.review_loop.wip_scope")

--- a/tests/test_review_loop.py
+++ b/tests/test_review_loop.py
@@ -443,6 +443,11 @@ class TestPrepareWipScope:
     ) -> LoopConfig:
         return make_loop_config(wip=True, log_dir=tmp_path / "logs", **kw)
 
+    def _resumable_logs(self, config: LoopConfig) -> None:
+        """Make ``detect_state`` see an interrupted run worth resuming."""
+        config.log_dir.mkdir(parents=True, exist_ok=True)
+        (config.log_dir / "review-1.json").write_text("{}")
+
     @patch("mr_overkill.review_loop.wip_scope")
     def test_non_wip_run_clears_a_stale_artefact(
         self,
@@ -486,6 +491,26 @@ class TestPrepareWipScope:
         assert config.scope_diff_file == config.log_dir / "wip.diff"
         assert config.skip_initial_no_diff is True
         mock_ws.create_scaffold_commit.assert_not_called()
+
+    @patch("mr_overkill.review_loop.wip_scope")
+    def test_a_previous_runs_fixes_diff_is_dropped(
+        self,
+        mock_ws: MagicMock,
+        tmp_path: Path,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        # Only a committing run writes it, and only at the very end, so a
+        # dry-run (or non-WIP) run would otherwise leave the README's
+        # "just what the loop changed" pointing at the previous run's edits.
+        mock_ws.uncommitted_files.return_value = ["a.py"]
+        mock_ws.write_worktree_diff.return_value = 512
+        config = self._config(make_loop_config, tmp_path, dry_run=True)
+        config.log_dir.mkdir(parents=True, exist_ok=True)
+        stale = config.log_dir / "wip-fixes.diff"
+        stale.write_text("--- a previous run's fixes\n")
+
+        assert _prepare_wip_scope(config) is True
+        assert not stale.exists()
 
     @patch("mr_overkill.review_loop.wip_scope")
     def test_no_auto_commit_also_takes_the_diff_path(
@@ -581,6 +606,7 @@ class TestPrepareWipScope:
         tmp_path: Path,
         make_loop_config: Callable[..., LoopConfig],
     ) -> None:
+        mock_ws.is_in_head.return_value = True
         config = self._config(
             make_loop_config,
             tmp_path,
@@ -590,6 +616,194 @@ class TestPrepareWipScope:
         )
         assert _prepare_wip_scope(config) is True
         mock_ws.create_scaffold_commit.assert_not_called()
+
+    @patch("mr_overkill.review_loop.commit_scope.resolve_commit")
+    @patch("mr_overkill.review_loop.wip_scope")
+    def test_resume_rescaffolds_when_the_scaffold_is_gone(
+        self,
+        mock_ws: MagicMock,
+        mock_resolve: MagicMock,
+        tmp_path: Path,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        # A soft failure unwinds the scaffolding but leaves wip-base.txt
+        # behind, so the work is uncommitted again by the time --resume runs.
+        # Taking the metadata at face value would let the loop's resume reset
+        # stash it away instead of reviewing it.
+        mock_ws.is_in_head.return_value = False
+        mock_ws.uncommitted_files.return_value = ["a.py"]
+        mock_ws.operation_in_progress.return_value = None
+        mock_resolve.return_value = "b" * 40
+        mock_ws.create_scaffold_commit.return_value = "d" * 40
+        config = self._config(
+            make_loop_config,
+            tmp_path,
+            resume=True,
+            wip_base="b" * 40,
+            wip_scaffold="c" * 40,
+        )
+        self._resumable_logs(config)
+        assert _prepare_wip_scope(config) is True
+        mock_ws.create_scaffold_commit.assert_called_once()
+        # Re-parking from the same base keeps loop_engine's resume check happy.
+        assert config.wip_base == "b" * 40
+        assert config.wip_scaffold == "d" * 40
+
+    @patch("mr_overkill.review_loop.commit_scope.resolve_commit")
+    @patch("mr_overkill.review_loop.wip_scope")
+    def test_a_rescaffold_records_the_new_sha(
+        self,
+        mock_ws: MagicMock,
+        mock_resolve: MagicMock,
+        tmp_path: Path,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        # loop_engine only saves metadata on fresh runs, so if this path does
+        # not write the SHA itself, wip-scaffold.txt keeps naming the dangling
+        # commit — and a run killed before its unwind leaves the work parked
+        # in a commit nothing on disk records.
+        mock_ws.is_in_head.return_value = False
+        mock_ws.uncommitted_files.return_value = ["a.py"]
+        mock_ws.operation_in_progress.return_value = None
+        mock_resolve.return_value = "b" * 40
+        mock_ws.create_scaffold_commit.return_value = "d" * 40
+        config = self._config(
+            make_loop_config,
+            tmp_path,
+            resume=True,
+            wip_base="b" * 40,
+            wip_scaffold="c" * 40,
+        )
+        self._resumable_logs(config)
+        assert _prepare_wip_scope(config) is True
+        mock_ws.save_metadata.assert_called_once_with(
+            config.log_dir, "b" * 40, "d" * 40
+        )
+
+    @patch("mr_overkill.review_loop.commit_scope.resolve_commit")
+    @patch("mr_overkill.review_loop.wip_scope")
+    def test_a_rescaffold_keeps_the_previous_attempts_fixes(
+        self,
+        mock_ws: MagicMock,
+        mock_resolve: MagicMock,
+        tmp_path: Path,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        # This run's unwind overwrites wip-fixes.diff, and re-parking folded
+        # the earlier fixes in with the user's own work, so the old diff is
+        # the only remaining record of what that attempt changed.
+        mock_ws.is_in_head.return_value = False
+        mock_ws.uncommitted_files.return_value = ["a.py"]
+        mock_ws.operation_in_progress.return_value = None
+        mock_resolve.return_value = "b" * 40
+        mock_ws.create_scaffold_commit.return_value = "d" * 40
+        config = self._config(
+            make_loop_config,
+            tmp_path,
+            resume=True,
+            wip_base="b" * 40,
+            wip_scaffold="c" * 40,
+        )
+        self._resumable_logs(config)
+        (config.log_dir / "wip-fixes.diff").write_text("--- attempt 1's fixes\n")
+
+        assert _prepare_wip_scope(config) is True
+        assert not (config.log_dir / "wip-fixes.diff").exists()
+        kept = config.log_dir / f"wip-fixes-{'c' * 7}.diff"
+        assert kept.read_text() == "--- attempt 1's fixes\n"
+
+    @patch("mr_overkill.review_loop.commit_scope.resolve_commit")
+    @patch("mr_overkill.review_loop.wip_scope")
+    def test_a_finished_run_is_not_reparked(
+        self,
+        mock_ws: MagicMock,
+        mock_resolve: MagicMock,
+        tmp_path: Path,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        # A run that finished normally also unwinds its scaffolding and also
+        # leaves the metadata behind, so the dangling SHA looks exactly like
+        # an interrupted run's. Re-parking here would sweep the tree into a
+        # commit the loop short-circuits past and then unwind it again, for a
+        # command that used to be a no-op.
+        mock_ws.is_in_head.return_value = False
+        mock_ws.uncommitted_files.return_value = ["a.py"]
+        mock_resolve.return_value = "b" * 40
+        config = self._config(
+            make_loop_config,
+            tmp_path,
+            resume=True,
+            wip_base="b" * 40,
+            wip_scaffold="c" * 40,
+        )
+        config.log_dir.mkdir(parents=True, exist_ok=True)
+        (config.log_dir / "summary.md").write_text("**Final status**: all_clear\n")
+        (config.log_dir / "wip-fixes.diff").write_text("--- the finished run\n")
+
+        assert _prepare_wip_scope(config) is True
+        mock_ws.create_scaffold_commit.assert_not_called()
+        assert (config.log_dir / "wip-fixes.diff").read_text() == (
+            "--- the finished run\n"
+        )
+
+    @patch("mr_overkill.review_loop.commit_scope.resolve_commit")
+    @patch("mr_overkill.review_loop.wip_scope")
+    def test_an_aborted_repark_leaves_the_fixes_diff_alone(
+        self,
+        mock_ws: MagicMock,
+        mock_resolve: MagicMock,
+        tmp_path: Path,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        # The artefact is only doomed once the new scaffolding exists. Bailing
+        # out before that and still having renamed it would break the command
+        # the README documents on a run that did nothing.
+        mock_ws.is_in_head.return_value = False
+        mock_ws.uncommitted_files.return_value = ["a.py"]
+        mock_ws.operation_in_progress.return_value = "merge"
+        mock_resolve.return_value = "b" * 40
+        config = self._config(
+            make_loop_config,
+            tmp_path,
+            resume=True,
+            wip_base="b" * 40,
+            wip_scaffold="c" * 40,
+        )
+        self._resumable_logs(config)
+        (config.log_dir / "wip-fixes.diff").write_text("--- attempt 1's fixes\n")
+
+        assert _prepare_wip_scope(config) is False
+        assert (config.log_dir / "wip-fixes.diff").read_text() == (
+            "--- attempt 1's fixes\n"
+        )
+        assert not list(config.log_dir.glob("wip-fixes-*.diff"))
+
+    @patch("mr_overkill.review_loop.commit_scope.resolve_commit")
+    @patch("mr_overkill.review_loop.wip_scope")
+    def test_a_clean_tree_while_rescaffolding_points_at_the_base(
+        self,
+        mock_ws: MagicMock,
+        mock_resolve: MagicMock,
+        tmp_path: Path,
+        make_loop_config: Callable[..., LoopConfig],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        # Nothing uncommitted and nothing in the recorded scaffolding means an
+        # earlier run was killed before it could unwind: the work sits in a
+        # commit of its own and only the base leads back to it.
+        mock_ws.is_in_head.return_value = False
+        mock_ws.uncommitted_files.return_value = []
+        mock_resolve.return_value = "e" * 40
+        config = self._config(
+            make_loop_config,
+            tmp_path,
+            resume=True,
+            wip_base="b" * 40,
+            wip_scaffold="c" * 40,
+        )
+        self._resumable_logs(config)
+        assert _prepare_wip_scope(config) is False
+        assert f"git reset --mixed {'b' * 40}" in caplog.text
 
     @patch("mr_overkill.review_loop.wip_scope")
     def test_resume_without_a_recorded_base_refuses(

--- a/tests/test_review_loop.py
+++ b/tests/test_review_loop.py
@@ -499,15 +499,16 @@ class TestPrepareWipScope:
         mock_ws.create_scaffold_commit.assert_not_called()
 
     @patch("mr_overkill.review_loop.wip_scope")
-    def test_a_previous_runs_fixes_diff_is_dropped(
+    def test_a_previous_runs_fixes_diff_survives_a_no_commit_run(
         self,
         mock_ws: MagicMock,
         tmp_path: Path,
         make_loop_config: Callable[..., LoopConfig],
     ) -> None:
         # Only a committing run writes it, and only at the very end, so a
-        # dry-run (or non-WIP) run would otherwise leave the README's
-        # "just what the loop changed" pointing at the previous run's edits.
+        # dry-run produces no replacement.  Dropping it here would destroy the
+        # only record separating the previous loop's fixes from the author's
+        # own edits, in exchange for nothing.
         mock_ws.uncommitted_files.return_value = ["a.py"]
         mock_ws.write_worktree_diff.return_value = 512
         config = self._config(make_loop_config, tmp_path, dry_run=True)
@@ -516,7 +517,7 @@ class TestPrepareWipScope:
         stale.write_text("--- a previous run's fixes\n")
 
         assert _prepare_wip_scope(config) is True
-        assert not stale.exists()
+        assert stale.read_text() == "--- a previous run's fixes\n"
 
     @patch("mr_overkill.review_loop.wip_scope")
     def test_no_auto_commit_also_takes_the_diff_path(
@@ -556,7 +557,7 @@ class TestPrepareWipScope:
     ) -> None:
         mock_ws.uncommitted_files.return_value = ["a.py"]
         mock_ws.operation_in_progress.return_value = None
-        mock_ws.head_is_scaffold.return_value = False
+        mock_ws.find_scaffold_in_head.return_value = None
         mock_resolve.return_value = "b" * 40
         mock_ws.create_scaffold_commit.return_value = "c" * 40
         config = self._config(make_loop_config, tmp_path)
@@ -615,6 +616,7 @@ class TestPrepareWipScope:
     ) -> None:
         mock_ws.operation_in_progress.return_value = None
         mock_ws.is_in_head.return_value = True
+        mock_ws.foreign_commits_since.return_value = []
         config = self._config(
             make_loop_config,
             tmp_path,
@@ -641,13 +643,37 @@ class TestPrepareWipScope:
         # on the branch while the loop reports the tree merely dirty.
         mock_ws.uncommitted_files.return_value = ["a.py"]
         mock_ws.operation_in_progress.return_value = None
-        mock_ws.head_is_scaffold.return_value = True
+        mock_ws.find_scaffold_in_head.return_value = "e" * 40
         mock_resolve.return_value = "b" * 40
         config = self._config(make_loop_config, tmp_path)
 
         assert _prepare_wip_scope(config) is False
         mock_ws.create_scaffold_commit.assert_not_called()
         mock_ws.save_metadata.assert_not_called()
+
+    @patch("mr_overkill.review_loop.wip_scope")
+    def test_resume_refuses_when_a_foreign_commit_sits_on_the_scaffold(
+        self,
+        mock_ws: MagicMock,
+        tmp_path: Path,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        # The unwind resets to the base, so a normal commit the user made on
+        # top of an interrupted run would be rewound into uncommitted changes
+        # — the branch check alone does not prove the range is the loop's.
+        mock_ws.operation_in_progress.return_value = None
+        mock_ws.is_in_head.return_value = True
+        mock_ws.foreign_commits_since.return_value = ["feat: my own work"]
+        config = self._config(
+            make_loop_config,
+            tmp_path,
+            resume=True,
+            wip_base="b" * 40,
+            wip_scaffold="c" * 40,
+        )
+
+        assert _prepare_wip_scope(config) is False
+        mock_ws.create_scaffold_commit.assert_not_called()
 
     @patch("mr_overkill.review_loop.wip_scope")
     def test_resume_on_another_branch_refuses(
@@ -709,7 +735,7 @@ class TestPrepareWipScope:
         mock_ws.is_in_head.return_value = False
         mock_ws.uncommitted_files.return_value = ["a.py"]
         mock_ws.operation_in_progress.return_value = None
-        mock_ws.head_is_scaffold.return_value = True
+        mock_ws.find_scaffold_in_head.return_value = "e" * 40
         mock_resolve.return_value = "b" * 40
         mock_ws.create_scaffold_commit.return_value = "d" * 40
         config = self._config(

--- a/tests/test_review_loop.py
+++ b/tests/test_review_loop.py
@@ -524,6 +524,7 @@ class TestPrepareWipScope:
         make_loop_config: Callable[..., LoopConfig],
     ) -> None:
         mock_ws.uncommitted_files.return_value = ["a.py"]
+        mock_ws.operation_in_progress.return_value = None
         mock_resolve.return_value = "b" * 40
         mock_ws.create_scaffold_commit.return_value = "c" * 40
         config = self._config(make_loop_config, tmp_path)
@@ -547,12 +548,31 @@ class TestPrepareWipScope:
         make_loop_config: Callable[..., LoopConfig],
     ) -> None:
         mock_ws.uncommitted_files.return_value = ["a.py"]
+        mock_ws.operation_in_progress.return_value = None
         mock_resolve.return_value = "b" * 40
         mock_ws.create_scaffold_commit.return_value = None
         config = self._config(make_loop_config, tmp_path)
 
         assert _prepare_wip_scope(config) is False
         assert config.wip_base is None
+
+    @patch("mr_overkill.review_loop.commit_scope.resolve_commit")
+    @patch("mr_overkill.review_loop.wip_scope")
+    def test_unfinished_merge_blocks_scaffolding(
+        self,
+        mock_ws: MagicMock,
+        mock_resolve: MagicMock,
+        tmp_path: Path,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        # The scaffolding commit would conclude the merge, and unwinding
+        # would then reset past it.
+        mock_ws.uncommitted_files.return_value = ["a.py"]
+        mock_ws.operation_in_progress.return_value = "merge"
+        config = self._config(make_loop_config, tmp_path)
+
+        assert _prepare_wip_scope(config) is False
+        mock_ws.create_scaffold_commit.assert_not_called()
 
     @patch("mr_overkill.review_loop.wip_scope")
     def test_resume_reuses_the_existing_scaffold(
@@ -626,6 +646,26 @@ class TestWipUnwind:
         with pytest.raises(RuntimeError):
             run(config)
         mock_ws.unwind.assert_called_once()
+
+    @patch("mr_overkill.review_loop.wip_scope")
+    @patch("mr_overkill.review_loop.review_fix_loop")
+    @patch("mr_overkill.review_loop._prepare_wip_scope", return_value=True)
+    def test_a_failed_unwind_fails_the_run(
+        self,
+        mock_prep: MagicMock,
+        mock_loop: MagicMock,
+        mock_ws: MagicMock,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        # Exiting 0 would tell the caller no commits were left behind when
+        # some demonstrably were.
+        mock_loop.return_value = LoopResult(
+            final_status=FinalStatus.ALL_CLEAR, iterations_run=1
+        )
+        mock_ws.unwind.return_value = False
+        config = make_loop_config(wip=True, wip_base="b" * 40, wip_scaffold="c" * 40)
+
+        assert run(config) == 1
 
     @patch("mr_overkill.review_loop.wip_scope")
     @patch("mr_overkill.review_loop.review_fix_loop")

--- a/tests/test_review_loop.py
+++ b/tests/test_review_loop.py
@@ -441,7 +441,13 @@ class TestPrepareWipScope:
         tmp_path: Path,
         **kw: object,
     ) -> LoopConfig:
-        return make_loop_config(wip=True, log_dir=tmp_path / "logs", **kw)
+        config = make_loop_config(wip=True, log_dir=tmp_path / "logs", **kw)
+        if config.resume:
+            # A resume identifies its scaffolding by the branch it was made
+            # on, which the interrupted run recorded here.
+            config.log_dir.mkdir(parents=True, exist_ok=True)
+            (config.log_dir / "branch.txt").write_text(config.current_branch)
+        return config
 
     def _resumable_logs(self, config: LoopConfig) -> None:
         """Make ``detect_state`` see an interrupted run worth resuming."""
@@ -607,6 +613,7 @@ class TestPrepareWipScope:
         tmp_path: Path,
         make_loop_config: Callable[..., LoopConfig],
     ) -> None:
+        mock_ws.operation_in_progress.return_value = None
         mock_ws.is_in_head.return_value = True
         config = self._config(
             make_loop_config,
@@ -641,6 +648,51 @@ class TestPrepareWipScope:
         assert _prepare_wip_scope(config) is False
         mock_ws.create_scaffold_commit.assert_not_called()
         mock_ws.save_metadata.assert_not_called()
+
+    @patch("mr_overkill.review_loop.wip_scope")
+    def test_resume_on_another_branch_refuses(
+        self,
+        mock_ws: MagicMock,
+        tmp_path: Path,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        # The scaffolding commit is in the history of every branch cut from
+        # it, so the ancestry test below would pass here and the unwind would
+        # reset this branch's own commits into uncommitted changes.
+        mock_ws.is_in_head.return_value = True
+        config = self._config(
+            make_loop_config,
+            tmp_path,
+            resume=True,
+            wip_base="b" * 40,
+            wip_scaffold="c" * 40,
+        )
+        (config.log_dir / "branch.txt").write_text("feat/somewhere-else")
+
+        assert _prepare_wip_scope(config) is False
+        mock_ws.create_scaffold_commit.assert_not_called()
+
+    @patch("mr_overkill.review_loop.wip_scope")
+    def test_resume_with_the_scaffold_in_head_still_checks_for_a_merge(
+        self,
+        mock_ws: MagicMock,
+        tmp_path: Path,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        # This resume commits without scaffolding again, so the guard has to
+        # sit ahead of it: a fix commit would conclude the merge, and the
+        # unwind's reset would then drop MERGE_HEAD.
+        mock_ws.operation_in_progress.return_value = "merge"
+        mock_ws.is_in_head.return_value = True
+        config = self._config(
+            make_loop_config,
+            tmp_path,
+            resume=True,
+            wip_base="b" * 40,
+            wip_scaffold="c" * 40,
+        )
+
+        assert _prepare_wip_scope(config) is False
 
     @patch("mr_overkill.review_loop.commit_scope.resolve_commit")
     @patch("mr_overkill.review_loop.wip_scope")
@@ -781,6 +833,7 @@ class TestPrepareWipScope:
         # an interrupted run's. Re-parking here would sweep the tree into a
         # commit the loop short-circuits past and then unwind it again, for a
         # command that used to be a no-op.
+        mock_ws.operation_in_progress.return_value = None
         mock_ws.is_in_head.return_value = False
         mock_ws.uncommitted_files.return_value = ["a.py"]
         mock_resolve.return_value = "b" * 40
@@ -851,6 +904,7 @@ class TestPrepareWipScope:
         # Nothing uncommitted and nothing in the recorded scaffolding means an
         # earlier run was killed before it could unwind: the work sits in a
         # commit of its own and only the base leads back to it.
+        mock_ws.operation_in_progress.return_value = None
         mock_ws.is_in_head.return_value = False
         mock_ws.uncommitted_files.return_value = []
         mock_resolve.return_value = "e" * 40
@@ -898,7 +952,7 @@ class TestWipUnwind:
 
         assert run(config) == 0
         mock_ws.unwind.assert_called_once_with(
-            "b" * 40, "c" * 40, config.log_dir
+            "b" * 40, "c" * 40, config.log_dir, branch=config.current_branch
         )
 
     @patch("mr_overkill.review_loop.wip_scope")

--- a/tests/test_review_loop.py
+++ b/tests/test_review_loop.py
@@ -6,8 +6,14 @@ from collections.abc import Callable
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from mr_overkill.models import FinalStatus, LoopConfig, LoopResult
-from mr_overkill.review_loop import _prepare_commit_scope, run
+from mr_overkill.review_loop import (
+    _prepare_commit_scope,
+    _prepare_wip_scope,
+    run,
+)
 
 
 class TestReviewLoopRun:
@@ -420,6 +426,248 @@ class TestCommitScopeRunWiring:
         )
         config = make_loop_config(
             scope_commit="a" * 40, ci_trigger_mode="last-only"
+        )
+        assert run(config) == 0
+        mock_trigger.assert_not_called()
+
+
+class TestPrepareWipScope:
+    """One flag, two mechanisms: a worktree diff when the run may not commit,
+    a scaffolding commit when it may."""
+
+    def _config(
+        self,
+        make_loop_config: Callable[..., LoopConfig],
+        tmp_path: Path,
+        **kw: object,
+    ) -> LoopConfig:
+        return make_loop_config(wip=True, log_dir=tmp_path / "logs", **kw)
+
+    @patch("mr_overkill.review_loop.wip_scope")
+    def test_non_wip_run_clears_a_stale_artefact(
+        self,
+        mock_ws: MagicMock,
+        tmp_path: Path,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        config = make_loop_config(log_dir=tmp_path / "logs")
+        stale = config.log_dir / "wip.diff"
+        stale.write_text("from a previous run")
+
+        assert _prepare_wip_scope(config) is True
+        assert not stale.exists()
+        mock_ws.uncommitted_files.assert_not_called()
+
+    @patch("mr_overkill.review_loop.wip_scope")
+    def test_clean_tree_refuses(
+        self,
+        mock_ws: MagicMock,
+        tmp_path: Path,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        mock_ws.uncommitted_files.return_value = []
+        config = self._config(make_loop_config, tmp_path, dry_run=True)
+
+        assert _prepare_wip_scope(config) is False
+        mock_ws.create_scaffold_commit.assert_not_called()
+
+    @patch("mr_overkill.review_loop.wip_scope")
+    def test_dry_run_captures_a_worktree_diff_instead_of_committing(
+        self,
+        mock_ws: MagicMock,
+        tmp_path: Path,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        mock_ws.uncommitted_files.return_value = ["a.py"]
+        mock_ws.write_worktree_diff.return_value = 512
+        config = self._config(make_loop_config, tmp_path, dry_run=True)
+
+        assert _prepare_wip_scope(config) is True
+        assert config.scope_diff_file == config.log_dir / "wip.diff"
+        assert config.skip_initial_no_diff is True
+        mock_ws.create_scaffold_commit.assert_not_called()
+
+    @patch("mr_overkill.review_loop.wip_scope")
+    def test_no_auto_commit_also_takes_the_diff_path(
+        self,
+        mock_ws: MagicMock,
+        tmp_path: Path,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        mock_ws.uncommitted_files.return_value = ["a.py"]
+        mock_ws.write_worktree_diff.return_value = 512
+        config = self._config(make_loop_config, tmp_path, auto_commit=False)
+
+        assert _prepare_wip_scope(config) is True
+        mock_ws.create_scaffold_commit.assert_not_called()
+
+    @patch("mr_overkill.review_loop.wip_scope")
+    def test_empty_worktree_diff_aborts(
+        self,
+        mock_ws: MagicMock,
+        tmp_path: Path,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        mock_ws.uncommitted_files.return_value = ["a.py"]
+        mock_ws.write_worktree_diff.return_value = 0
+        config = self._config(make_loop_config, tmp_path, dry_run=True)
+
+        assert _prepare_wip_scope(config) is False
+
+    @patch("mr_overkill.review_loop.commit_scope.resolve_commit")
+    @patch("mr_overkill.review_loop.wip_scope")
+    def test_committing_run_scaffolds_and_records_the_base(
+        self,
+        mock_ws: MagicMock,
+        mock_resolve: MagicMock,
+        tmp_path: Path,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        mock_ws.uncommitted_files.return_value = ["a.py"]
+        mock_resolve.return_value = "b" * 40
+        mock_ws.create_scaffold_commit.return_value = "c" * 40
+        config = self._config(make_loop_config, tmp_path)
+
+        assert _prepare_wip_scope(config) is True
+        assert config.wip_base == "b" * 40
+        assert config.wip_scaffold == "c" * 40
+        # The loop's own diff machinery sees the work as a real commit, so
+        # nothing needs to be skipped or handed over as an artefact.
+        assert config.scope_diff_file is None
+        assert config.skip_initial_no_diff is False
+        mock_ws.write_worktree_diff.assert_not_called()
+
+    @patch("mr_overkill.review_loop.commit_scope.resolve_commit")
+    @patch("mr_overkill.review_loop.wip_scope")
+    def test_failed_scaffold_aborts(
+        self,
+        mock_ws: MagicMock,
+        mock_resolve: MagicMock,
+        tmp_path: Path,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        mock_ws.uncommitted_files.return_value = ["a.py"]
+        mock_resolve.return_value = "b" * 40
+        mock_ws.create_scaffold_commit.return_value = None
+        config = self._config(make_loop_config, tmp_path)
+
+        assert _prepare_wip_scope(config) is False
+        assert config.wip_base is None
+
+    @patch("mr_overkill.review_loop.wip_scope")
+    def test_resume_reuses_the_existing_scaffold(
+        self,
+        mock_ws: MagicMock,
+        tmp_path: Path,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        config = self._config(
+            make_loop_config,
+            tmp_path,
+            resume=True,
+            wip_base="b" * 40,
+            wip_scaffold="c" * 40,
+        )
+        assert _prepare_wip_scope(config) is True
+        mock_ws.create_scaffold_commit.assert_not_called()
+
+    @patch("mr_overkill.review_loop.wip_scope")
+    def test_resume_without_a_recorded_base_refuses(
+        self,
+        mock_ws: MagicMock,
+        tmp_path: Path,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        # Scaffolding again would stack a second throwaway commit and lose
+        # the only record of where to unwind to.
+        config = self._config(make_loop_config, tmp_path, resume=True)
+        assert _prepare_wip_scope(config) is False
+        mock_ws.create_scaffold_commit.assert_not_called()
+
+
+class TestWipUnwind:
+    @patch("mr_overkill.review_loop.wip_scope")
+    @patch("mr_overkill.review_loop.review_fix_loop")
+    @patch("mr_overkill.review_loop._prepare_wip_scope", return_value=True)
+    def test_scaffolding_comes_down_after_a_normal_run(
+        self,
+        mock_prep: MagicMock,
+        mock_loop: MagicMock,
+        mock_ws: MagicMock,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        mock_loop.return_value = LoopResult(
+            final_status=FinalStatus.ALL_CLEAR, iterations_run=1
+        )
+        mock_ws.unwind.return_value = True
+        config = make_loop_config(wip=True, wip_base="b" * 40, wip_scaffold="c" * 40)
+
+        assert run(config) == 0
+        mock_ws.unwind.assert_called_once_with(
+            "b" * 40, "c" * 40, config.log_dir
+        )
+
+    @patch("mr_overkill.review_loop.wip_scope")
+    @patch("mr_overkill.review_loop.review_fix_loop")
+    @patch("mr_overkill.review_loop._prepare_wip_scope", return_value=True)
+    def test_scaffolding_comes_down_when_the_loop_raises(
+        self,
+        mock_prep: MagicMock,
+        mock_loop: MagicMock,
+        mock_ws: MagicMock,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        # A crash that left the scaffolding in place would be
+        # indistinguishable from commits the author meant to keep.
+        mock_loop.side_effect = RuntimeError("boom")
+        mock_ws.unwind.return_value = True
+        config = make_loop_config(wip=True, wip_base="b" * 40, wip_scaffold="c" * 40)
+
+        with pytest.raises(RuntimeError):
+            run(config)
+        mock_ws.unwind.assert_called_once()
+
+    @patch("mr_overkill.review_loop.wip_scope")
+    @patch("mr_overkill.review_loop.review_fix_loop")
+    @patch("mr_overkill.review_loop._prepare_wip_scope", return_value=True)
+    def test_nothing_to_unwind_without_a_scaffold(
+        self,
+        mock_prep: MagicMock,
+        mock_loop: MagicMock,
+        mock_ws: MagicMock,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        mock_loop.return_value = LoopResult(
+            final_status=FinalStatus.DRY_RUN, iterations_run=1
+        )
+        config = make_loop_config(wip=True, dry_run=True)
+
+        assert run(config) == 0
+        mock_ws.unwind.assert_not_called()
+
+    @patch("mr_overkill.review_loop.push_trigger_commit")
+    @patch("mr_overkill.review_loop.wip_scope")
+    @patch("mr_overkill.review_loop.review_fix_loop")
+    @patch("mr_overkill.review_loop._prepare_wip_scope", return_value=True)
+    def test_no_ci_trigger_commit_in_wip_mode(
+        self,
+        mock_prep: MagicMock,
+        mock_loop: MagicMock,
+        mock_ws: MagicMock,
+        mock_trigger: MagicMock,
+        make_loop_config: Callable[..., LoopConfig],
+    ) -> None:
+        mock_loop.return_value = LoopResult(
+            final_status=FinalStatus.ALL_CLEAR,
+            iterations_run=2,
+            made_skipped_fix_commit=True,
+        )
+        mock_ws.unwind.return_value = True
+        config = make_loop_config(
+            wip=True,
+            wip_base="b" * 40,
+            wip_scaffold="c" * 40,
+            ci_trigger_mode="last-only",
         )
         assert run(config) == 0
         mock_trigger.assert_not_called()

--- a/tests/test_self_review.py
+++ b/tests/test_self_review.py
@@ -403,6 +403,63 @@ class TestFixNitsGuidelines:
         "mr_overkill.self_review.changed_files_since_snapshot",
         return_value=["src/foo.py"],
     )
+    def test_scope_note_joins_the_guidelines(
+        self,
+        mock_changed: MagicMock,
+        mock_diff: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """scope_note reaches the prompt without displacing fix-nits."""
+        prompts = _make_prompts(tmp_path)
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+
+        def write_diff(
+            changed: list[str], output: Path, cwd: Path | None
+        ) -> None:
+            output.write_text("diff --git a/foo b/foo\n")
+
+        mock_diff.side_effect = write_diff
+
+        captured_prompt: list[str] = []
+
+        def fake_retry(
+            output_path: Path, label: str, cmd_args: list[str], **kw: object
+        ) -> bool:
+            captured_prompt.append(str(kw.get("stdin", "")))
+            output_path.write_text(
+                json.dumps({
+                    "findings": [],
+                    "overall_correctness": "patch is correct",
+                })
+            )
+            return True
+
+        self_review_subloop(
+            pre_fix_snapshot=_make_snapshot(),
+            max_subloop=4,
+            log_dir=log_dir,
+            iteration=1,
+            review_json_str="{}",
+            retry_fn=fake_retry,
+            budget_fn=MagicMock(return_value=True),
+            fix_fn=MagicMock(),
+            prompts_dir=prompts,
+            current_branch="feat/x",
+            target_branch="develop",
+            fix_nits=True,
+            scope_note="\n### the author's draft is in here too\n",
+        )
+
+        assert len(captured_prompt) == 1
+        assert "Fix nits and potential issues" in captured_prompt[0]
+        assert "the author's draft is in here too" in captured_prompt[0]
+
+    @patch("mr_overkill.self_review._generate_diff")
+    @patch(
+        "mr_overkill.self_review.changed_files_since_snapshot",
+        return_value=["src/foo.py"],
+    )
     def test_fix_nits_false_empty_guidelines(
         self,
         mock_changed: MagicMock,

--- a/tests/test_wip_scope.py
+++ b/tests/test_wip_scope.py
@@ -1,0 +1,304 @@
+"""Tests for wip_scope — run against a real git repo, not mocks.
+
+Every function here exists because of a git behaviour that is easy to get
+wrong and impossible to observe through a mock: untracked files are invisible
+to ``git diff`` until they are staged as intent-to-add, ``git add -A`` sweeps
+in the log directory unless a pathspec excludes it, and ``git reset --mixed``
+must leave file contents alone while moving the branch.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from mr_overkill.wip_scope import (
+    SCAFFOLD_MESSAGE,
+    create_scaffold_commit,
+    merge_base,
+    uncommitted_files,
+    unwind,
+    write_worktree_diff,
+)
+
+
+@pytest.fixture()
+def out_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """A place for artefacts that is *not* inside the repo under test.
+
+    ``tmp_git_repo`` is rooted at ``tmp_path``, so writing there would show up
+    as an untracked file and change the very status these tests assert on.
+    """
+    return tmp_path_factory.mktemp("wip-out")
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=True
+    )
+    return result.stdout.strip()
+
+
+def _status(repo: Path) -> str:
+    return _git(repo, "status", "--porcelain")
+
+
+def _write_log(repo: Path, name: str = "review-1.json") -> None:
+    log_dir = repo / ".overkill" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    (log_dir / name).write_text('{"findings": []}')
+
+
+class TestUncommittedFiles:
+    def test_clean_repo_is_empty(self, tmp_git_repo: Path) -> None:
+        assert uncommitted_files(tmp_git_repo) == []
+
+    def test_collects_modified_staged_and_untracked(
+        self, tmp_git_repo: Path
+    ) -> None:
+        (tmp_git_repo / "README.md").write_text("# changed\n")
+        (tmp_git_repo / "staged.py").write_text("x = 1\n")
+        _git(tmp_git_repo, "add", "staged.py")
+        (tmp_git_repo / "untracked.py").write_text("y = 2\n")
+
+        assert uncommitted_files(tmp_git_repo) == [
+            "README.md",
+            "staged.py",
+            "untracked.py",
+        ]
+
+    def test_log_artefacts_are_not_work_in_progress(
+        self, tmp_git_repo: Path
+    ) -> None:
+        _write_log(tmp_git_repo)
+        assert uncommitted_files(tmp_git_repo) == []
+
+
+class TestMergeBase:
+    def test_ancestor_target_is_its_own_merge_base(
+        self, tmp_git_repo: Path
+    ) -> None:
+        root = _git(tmp_git_repo, "rev-parse", "HEAD")
+        (tmp_git_repo / "a.txt").write_text("a\n")
+        _git(tmp_git_repo, "add", "a.txt")
+        _git(tmp_git_repo, "commit", "-m", "add a")
+
+        assert merge_base(root, tmp_git_repo) == root
+
+    def test_unrelated_history_returns_none(self, tmp_git_repo: Path) -> None:
+        # An orphan branch shares no history with HEAD at all.
+        _git(tmp_git_repo, "checkout", "-q", "--orphan", "orphan")
+        (tmp_git_repo / "other.txt").write_text("other\n")
+        _git(tmp_git_repo, "add", "other.txt")
+        _git(tmp_git_repo, "commit", "-m", "orphan root")
+
+        assert merge_base("master", tmp_git_repo) is None
+
+
+class TestWriteWorktreeDiff:
+    def test_captures_committed_and_uncommitted_together(
+        self, tmp_git_repo: Path, out_dir: Path
+    ) -> None:
+        base = _git(tmp_git_repo, "rev-parse", "HEAD")
+        (tmp_git_repo / "committed.py").write_text("committed = True\n")
+        _git(tmp_git_repo, "add", "committed.py")
+        _git(tmp_git_repo, "commit", "-m", "a real commit")
+        (tmp_git_repo / "modified.py").write_text("modified = True\n")
+        _git(tmp_git_repo, "add", "modified.py")
+        _git(tmp_git_repo, "commit", "-m", "another real commit")
+        (tmp_git_repo / "modified.py").write_text("modified = 'edited'\n")
+
+        out = out_dir / "wip.diff"
+        size = write_worktree_diff(base, out, tmp_git_repo)
+
+        text = out.read_text()
+        assert size == len(text.encode())
+        assert "committed = True" in text
+        assert "modified = 'edited'" in text
+
+    def test_untracked_files_are_included(
+        self, tmp_git_repo: Path, out_dir: Path
+    ) -> None:
+        # The reason intent-to-add exists: a plain ``git diff`` cannot see a
+        # brand-new file, which is exactly the kind of work being reviewed.
+        base = _git(tmp_git_repo, "rev-parse", "HEAD")
+        (tmp_git_repo / "brand_new.py").write_text("def hello(): ...\n")
+
+        plain = subprocess.run(
+            ["git", "diff", base],
+            cwd=tmp_git_repo,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert "brand_new.py" not in plain.stdout
+
+        out = out_dir / "wip.diff"
+        assert write_worktree_diff(base, out, tmp_git_repo) > 0
+        assert "brand_new.py" in out.read_text()
+        assert "def hello()" in out.read_text()
+
+    def test_staged_unstaged_split_survives(
+        self, tmp_git_repo: Path, out_dir: Path
+    ) -> None:
+        # Undoing intent-to-add with a blanket reset would unstage the user's
+        # own staged work; only the untracked paths may be touched.
+        base = _git(tmp_git_repo, "rev-parse", "HEAD")
+        (tmp_git_repo / "staged.py").write_text("staged = 1\n")
+        _git(tmp_git_repo, "add", "staged.py")
+        (tmp_git_repo / "README.md").write_text("# unstaged\n")
+        (tmp_git_repo / "untracked.py").write_text("untracked = 1\n")
+        before = _status(tmp_git_repo)
+
+        write_worktree_diff(base, out_dir / "wip.diff", tmp_git_repo)
+
+        assert _status(tmp_git_repo) == before
+
+    def test_log_artefacts_are_excluded(
+        self, tmp_git_repo: Path, out_dir: Path
+    ) -> None:
+        base = _git(tmp_git_repo, "rev-parse", "HEAD")
+        _write_log(tmp_git_repo)
+        (tmp_git_repo / "real.py").write_text("real = 1\n")
+
+        out = out_dir / "wip.diff"
+        write_worktree_diff(base, out, tmp_git_repo)
+
+        assert "real.py" in out.read_text()
+        assert "review-1.json" not in out.read_text()
+
+    def test_unrelated_target_reports_failure(
+        self, tmp_git_repo: Path, out_dir: Path
+    ) -> None:
+        out = out_dir / "wip.diff"
+        assert write_worktree_diff("nonexistent-branch", out, tmp_git_repo) == 0
+        assert not out.exists()
+
+
+class TestCreateScaffoldCommit:
+    def test_parks_everything_and_leaves_a_clean_tree(
+        self, tmp_git_repo: Path
+    ) -> None:
+        (tmp_git_repo / "README.md").write_text("# changed\n")
+        (tmp_git_repo / "new.py").write_text("new = 1\n")
+
+        sha = create_scaffold_commit(tmp_git_repo)
+
+        assert sha == _git(tmp_git_repo, "rev-parse", "HEAD")
+        assert _status(tmp_git_repo) == ""
+        assert SCAFFOLD_MESSAGE in _git(tmp_git_repo, "log", "-1", "--format=%s%n%b")
+        files = _git(tmp_git_repo, "show", "--name-only", "--format=", sha).split()
+        assert sorted(files) == ["README.md", "new.py"]
+
+    def test_log_directory_stays_out_of_the_commit(
+        self, tmp_git_repo: Path
+    ) -> None:
+        _write_log(tmp_git_repo)
+        (tmp_git_repo / "real.py").write_text("real = 1\n")
+
+        sha = create_scaffold_commit(tmp_git_repo)
+        assert sha is not None
+
+        files = _git(tmp_git_repo, "show", "--name-only", "--format=", sha).split()
+        assert files == ["real.py"]
+
+    def test_clean_tree_refuses(self, tmp_git_repo: Path) -> None:
+        head = _git(tmp_git_repo, "rev-parse", "HEAD")
+        assert create_scaffold_commit(tmp_git_repo) is None
+        assert _git(tmp_git_repo, "rev-parse", "HEAD") == head
+
+    def test_failing_pre_commit_hook_does_not_block(
+        self, tmp_git_repo: Path
+    ) -> None:
+        # Work in progress routinely fails hooks it will pass once finished.
+        hook = tmp_git_repo / ".git" / "hooks" / "pre-commit"
+        hook.write_text("#!/bin/sh\nexit 1\n")
+        hook.chmod(0o755)
+        (tmp_git_repo / "wip.py").write_text("wip = 1\n")
+
+        assert create_scaffold_commit(tmp_git_repo) is not None
+        assert _status(tmp_git_repo) == ""
+
+
+class TestUnwind:
+    def _scaffold_then_fix(self, repo: Path) -> tuple[str, str]:
+        """Simulate a full run: park WIP, then commit an AI fix on top."""
+        base = _git(repo, "rev-parse", "HEAD")
+        (repo / "feature.py").write_text("def f():\n    return 1\n")
+        scaffold = create_scaffold_commit(repo)
+        assert scaffold is not None
+        (repo / "feature.py").write_text("def f() -> int:\n    return 1\n")
+        _git(repo, "add", "feature.py")
+        _git(repo, "commit", "-m", "fix: add a type hint")
+        return base, scaffold
+
+    def test_restores_history_and_keeps_the_work(
+        self, tmp_git_repo: Path, out_dir: Path
+    ) -> None:
+        base, scaffold = self._scaffold_then_fix(tmp_git_repo)
+
+        assert unwind(base, scaffold, out_dir, tmp_git_repo)
+
+        assert _git(tmp_git_repo, "rev-parse", "HEAD") == base
+        # The fixed content survives the reset, uncommitted.
+        assert (tmp_git_repo / "feature.py").read_text() == (
+            "def f() -> int:\n    return 1\n"
+        )
+        assert "feature.py" in _status(tmp_git_repo)
+
+    def test_leaves_nothing_staged(
+        self, tmp_git_repo: Path, out_dir: Path
+    ) -> None:
+        base, scaffold = self._scaffold_then_fix(tmp_git_repo)
+
+        unwind(base, scaffold, out_dir, tmp_git_repo)
+
+        assert _git(tmp_git_repo, "diff", "--cached", "--name-only") == ""
+
+    def test_saves_the_ai_net_change(
+        self, tmp_git_repo: Path, out_dir: Path
+    ) -> None:
+        # Once the scaffolding is gone there is no way left to tell the
+        # author's own work from the loop's edits, so it is saved first.
+        base, scaffold = self._scaffold_then_fix(tmp_git_repo)
+
+        unwind(base, scaffold, out_dir, tmp_git_repo)
+
+        fixes = (out_dir / "wip-fixes.diff").read_text()
+        assert "def f() -> int:" in fixes
+        assert "-def f():" in fixes
+
+    def test_is_idempotent(self, tmp_git_repo: Path, out_dir: Path) -> None:
+        base, scaffold = self._scaffold_then_fix(tmp_git_repo)
+        unwind(base, scaffold, out_dir, tmp_git_repo)
+
+        assert unwind(base, scaffold, out_dir, tmp_git_repo)
+        assert _git(tmp_git_repo, "rev-parse", "HEAD") == base
+
+    def test_refuses_when_base_is_not_an_ancestor(
+        self, tmp_git_repo: Path, out_dir: Path
+    ) -> None:
+        # Resetting to a commit HEAD does not descend from would move the
+        # branch somewhere it has never been.
+        (tmp_git_repo / "earlier.py").write_text("earlier = 1\n")
+        _git(tmp_git_repo, "add", "earlier.py")
+        _git(tmp_git_repo, "commit", "-m", "an earlier commit")
+        base, scaffold = self._scaffold_then_fix(tmp_git_repo)
+        _git(tmp_git_repo, "checkout", "-q", "-b", "elsewhere", base + "^")
+        head = _git(tmp_git_repo, "rev-parse", "HEAD")
+
+        assert not unwind(base, scaffold, out_dir, tmp_git_repo)
+        assert _git(tmp_git_repo, "rev-parse", "HEAD") == head
+
+    def test_no_scaffold_recorded_still_resets(
+        self, tmp_git_repo: Path, out_dir: Path
+    ) -> None:
+        base = _git(tmp_git_repo, "rev-parse", "HEAD")
+        (tmp_git_repo / "x.py").write_text("x = 1\n")
+        create_scaffold_commit(tmp_git_repo)
+
+        assert unwind(base, None, out_dir, tmp_git_repo)
+        assert _git(tmp_git_repo, "rev-parse", "HEAD") == base
+        assert not (out_dir / "wip-fixes.diff").exists()

--- a/tests/test_wip_scope.py
+++ b/tests/test_wip_scope.py
@@ -204,6 +204,31 @@ class TestCreateScaffoldCommit:
         files = _git(tmp_git_repo, "show", "--name-only", "--format=", sha).split()
         assert files == ["real.py"]
 
+    def test_gitignored_log_directory_does_not_abort_the_add(
+        self, tmp_git_repo: Path
+    ) -> None:
+        """Regression: excluding the log dir by pathspec makes git refuse the
+        whole add when that directory is gitignored — which it usually is."""
+        (tmp_git_repo / ".gitignore").write_text(".overkill/\n")
+        _write_log(tmp_git_repo)
+        (tmp_git_repo / "real.py").write_text("real = 1\n")
+
+        sha = create_scaffold_commit(tmp_git_repo)
+
+        assert sha is not None
+        files = _git(tmp_git_repo, "show", "--name-only", "--format=", sha).split()
+        assert sorted(files) == [".gitignore", "real.py"]
+        assert _status(tmp_git_repo) == ""
+
+    def test_deletions_are_staged(self, tmp_git_repo: Path) -> None:
+        (tmp_git_repo / "README.md").unlink()
+
+        sha = create_scaffold_commit(tmp_git_repo)
+
+        assert sha is not None
+        assert _status(tmp_git_repo) == ""
+        assert not (tmp_git_repo / "README.md").exists()
+
     def test_clean_tree_refuses(self, tmp_git_repo: Path) -> None:
         head = _git(tmp_git_repo, "rev-parse", "HEAD")
         assert create_scaffold_commit(tmp_git_repo) is None

--- a/tests/test_wip_scope.py
+++ b/tests/test_wip_scope.py
@@ -259,6 +259,42 @@ class TestCreateScaffoldCommit:
         assert _status(tmp_git_repo) == ""
         assert not (tmp_git_repo / "README.md").exists()
 
+    def test_a_staged_rename_takes_both_of_its_paths(
+        self, tmp_git_repo: Path
+    ) -> None:
+        """``--name-only`` names a rename's destination and nothing else.
+
+        Committing that alone leaves the source's deletion staged, so the tree
+        is still dirty when the loop's clean-tree check runs.
+        """
+        _git(tmp_git_repo, "mv", "README.md", "DOCS.md")
+
+        sha = create_scaffold_commit(tmp_git_repo)
+
+        assert sha is not None
+        assert _status(tmp_git_repo) == ""
+        assert _git(
+            tmp_git_repo, "show", "--name-status", "--format=", sha
+        ) == "R100\tREADME.md\tDOCS.md"
+
+    def test_an_already_staged_deletion_is_committed(
+        self, tmp_git_repo: Path
+    ) -> None:
+        """``git add`` cannot match a path that is in neither tree nor index.
+
+        A ``git rm``'d path is exactly that, and naming it makes the add abort,
+        which used to take the whole run down before it started.
+        """
+        _git(tmp_git_repo, "rm", "--quiet", "README.md")
+
+        sha = create_scaffold_commit(tmp_git_repo)
+
+        assert sha is not None
+        assert _status(tmp_git_repo) == ""
+        assert _git(
+            tmp_git_repo, "show", "--name-status", "--format=", sha
+        ) == "D\tREADME.md"
+
     def test_clean_tree_refuses(self, tmp_git_repo: Path) -> None:
         head = _git(tmp_git_repo, "rev-parse", "HEAD")
         assert create_scaffold_commit(tmp_git_repo) is None

--- a/tests/test_wip_scope.py
+++ b/tests/test_wip_scope.py
@@ -17,7 +17,8 @@ import pytest
 from mr_overkill.wip_scope import (
     SCAFFOLD_MESSAGE,
     create_scaffold_commit,
-    head_is_scaffold,
+    find_scaffold_in_head,
+    foreign_commits_since,
     is_in_head,
     merge_base,
     operation_in_progress,
@@ -404,18 +405,38 @@ class TestIsInHead:
         assert is_in_head(scaffold, tmp_git_repo) is False
 
 
-class TestHeadIsScaffold:
+class TestFindScaffoldInHead:
     def test_a_leftover_scaffolding_commit_is_recognised(
         self, tmp_git_repo: Path
     ) -> None:
         # What a run killed before its unwind leaves behind.
         (tmp_git_repo / "feature.py").write_text("x = 1\n")
-        assert create_scaffold_commit(tmp_git_repo) is not None
+        scaffold = create_scaffold_commit(tmp_git_repo)
+        assert scaffold is not None
 
-        assert head_is_scaffold(tmp_git_repo) is True
+        assert find_scaffold_in_head(tmp_git_repo) == scaffold
+
+    def test_a_scaffold_behind_a_fix_commit_is_still_found(
+        self, tmp_git_repo: Path
+    ) -> None:
+        # A run interrupted after its first fix commit leaves the scaffolding
+        # one commit back.  Looking at HEAD alone would let a fresh run
+        # scaffold on top of it and unwind only as far as the fix commit,
+        # stranding both on the branch.
+        (tmp_git_repo / "feature.py").write_text("x = 1\n")
+        scaffold = create_scaffold_commit(tmp_git_repo)
+        assert scaffold is not None
+        (tmp_git_repo / "feature.py").write_text("x = 2\n")
+        _git(tmp_git_repo, "add", "feature.py")
+        _git(
+            tmp_git_repo, "commit", "--quiet", "--no-verify",
+            "-m", "fix(ai-review): apply iteration 1 fixes [skip ci]",
+        )
+
+        assert find_scaffold_in_head(tmp_git_repo) == scaffold
 
     def test_an_ordinary_commit_is_not(self, tmp_git_repo: Path) -> None:
-        assert head_is_scaffold(tmp_git_repo) is False
+        assert find_scaffold_in_head(tmp_git_repo) is None
 
     def test_an_unwound_scaffold_is_not(self, tmp_git_repo: Path) -> None:
         base = _git(tmp_git_repo, "rev-parse", "HEAD")
@@ -423,7 +444,40 @@ class TestHeadIsScaffold:
         assert create_scaffold_commit(tmp_git_repo) is not None
         _git(tmp_git_repo, "reset", "--quiet", "--mixed", base)
 
-        assert head_is_scaffold(tmp_git_repo) is False
+        assert find_scaffold_in_head(tmp_git_repo) is None
+
+
+class TestForeignCommitsSince:
+    def test_the_loops_own_fix_commits_are_not_foreign(
+        self, tmp_git_repo: Path
+    ) -> None:
+        (tmp_git_repo / "feature.py").write_text("x = 1\n")
+        scaffold = create_scaffold_commit(tmp_git_repo)
+        assert scaffold is not None
+        (tmp_git_repo / "feature.py").write_text("x = 2\n")
+        _git(tmp_git_repo, "add", "feature.py")
+        _git(
+            tmp_git_repo, "commit", "--quiet", "--no-verify",
+            "-m", "fix(ai-review): apply iteration 1 fixes [skip ci]",
+        )
+
+        assert foreign_commits_since(
+            scaffold, "fix(ai-review): apply iteration", tmp_git_repo
+        ) == []
+
+    def test_a_users_own_commit_is_foreign(self, tmp_git_repo: Path) -> None:
+        # Unwinding resets to the base, so this commit would be rewound into
+        # uncommitted changes even though the branch name matches.
+        (tmp_git_repo / "feature.py").write_text("x = 1\n")
+        scaffold = create_scaffold_commit(tmp_git_repo)
+        assert scaffold is not None
+        (tmp_git_repo / "other.py").write_text("y = 1\n")
+        _git(tmp_git_repo, "add", "other.py")
+        _git(tmp_git_repo, "commit", "--quiet", "--no-verify", "-m", "feat: mine")
+
+        assert foreign_commits_since(
+            scaffold, "fix(ai-review): apply iteration", tmp_git_repo
+        ) == ["feat: mine"]
 
 
 class TestSaveMetadata:

--- a/tests/test_wip_scope.py
+++ b/tests/test_wip_scope.py
@@ -214,6 +214,26 @@ class TestCreateScaffoldCommit:
         files = _git(tmp_git_repo, "show", "--name-only", "--format=", sha).split()
         assert files == ["real.py"]
 
+    def test_an_already_staged_log_artefact_stays_out_of_the_commit(
+        self, tmp_git_repo: Path
+    ) -> None:
+        """Filtering the *add* is not enough: committing the whole index would
+        put a log file the user had staged themselves into the scaffolding
+        commit, and so into the diff the reviewer reads."""
+        _write_log(tmp_git_repo)
+        _git(tmp_git_repo, "add", ".overkill/logs/review-1.json")
+        (tmp_git_repo / "real.py").write_text("real = 1\n")
+
+        sha = create_scaffold_commit(tmp_git_repo)
+        assert sha is not None
+
+        files = _git(tmp_git_repo, "show", "--name-only", "--format=", sha).split()
+        assert files == ["real.py"]
+        # Left staged exactly as the user had it — not committed, not reset.
+        assert _git(tmp_git_repo, "diff", "--cached", "--name-only") == (
+            ".overkill/logs/review-1.json"
+        )
+
     def test_gitignored_log_directory_does_not_abort_the_add(
         self, tmp_git_repo: Path
     ) -> None:
@@ -480,6 +500,43 @@ class TestUnwind:
 
         assert not unwind(base, None, out_dir, tmp_git_repo)
         assert _git(tmp_git_repo, "rev-parse", "HEAD") == head
+
+    def test_refuses_on_a_branch_cut_from_the_scaffolding(
+        self, tmp_git_repo: Path, out_dir: Path
+    ) -> None:
+        """Ancestry is not identity: a branch cut from the scaffolding commit
+        has it in its history too, so resetting on the strength of that would
+        turn this branch's own commits into uncommitted changes."""
+        base, scaffold = self._scaffold_then_fix(tmp_git_repo)
+        original = _branch(tmp_git_repo)
+        _git(tmp_git_repo, "checkout", "-q", "-b", "descendant")
+        (tmp_git_repo / "later.py").write_text("later = 1\n")
+        _git(tmp_git_repo, "add", "later.py")
+        _git(tmp_git_repo, "commit", "-m", "work on the descendant branch")
+        head = _git(tmp_git_repo, "rev-parse", "HEAD")
+
+        assert not unwind(base, scaffold, out_dir, tmp_git_repo, branch=original)
+        assert _git(tmp_git_repo, "rev-parse", "HEAD") == head
+
+    def test_saves_uncommitted_fixer_edits(
+        self, tmp_git_repo: Path, out_dir: Path
+    ) -> None:
+        """A fixer that edits files and then fails leaves HEAD at the
+        scaffolding commit, so a commit-to-commit diff would report nothing
+        and the reset would fold those edits into the author's own work."""
+        (tmp_git_repo / "feature.py").write_text("def f():\n    return 1\n")
+        base = _git(tmp_git_repo, "rev-parse", "HEAD")
+        scaffold = create_scaffold_commit(tmp_git_repo)
+        (tmp_git_repo / "feature.py").write_text("def f() -> int:\n    return 1\n")
+        (tmp_git_repo / "added_by_the_fixer.py").write_text("helper = 1\n")
+
+        assert unwind(base, scaffold, out_dir, tmp_git_repo)
+
+        fixes = (out_dir / "wip-fixes.diff").read_text()
+        assert "def f() -> int:" in fixes
+        assert "added_by_the_fixer.py" in fixes
+        # The intent-to-add used to make the new file visible is undone.
+        assert _git(tmp_git_repo, "diff", "--cached", "--name-only") == ""
 
     def test_refuses_on_a_sibling_branch(
         self, tmp_git_repo: Path, out_dir: Path

--- a/tests/test_wip_scope.py
+++ b/tests/test_wip_scope.py
@@ -243,6 +243,54 @@ class TestCreateScaffoldCommit:
         assert create_scaffold_commit(tmp_git_repo) is None
         assert _git(tmp_git_repo, "rev-parse", "HEAD") == head
 
+    def test_a_failed_commit_says_the_index_is_left_staged(
+        self, tmp_git_repo: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # ``--no-verify`` skips hooks but not signing, so a repo that signs
+        # commits with an unavailable key fails here with everything staged.
+        _git(tmp_git_repo, "config", "commit.gpgsign", "true")
+        _git(tmp_git_repo, "config", "gpg.program", "false")
+        (tmp_git_repo / "wip.py").write_text("wip = 1\n")
+
+        assert create_scaffold_commit(tmp_git_repo) is None
+
+        assert "is left in the index" in caplog.text
+        assert _status(tmp_git_repo) == "A  wip.py"
+
+    def test_a_failed_commit_reports_a_reason_from_stdout(
+        self,
+        tmp_git_repo: Path,
+        out_dir: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        # A submodule whose gitlink did not move is dirty to ``git diff`` but
+        # stages nothing, so the commit fails with "no changes added to commit"
+        # — which git prints on stdout, leaving stderr empty and the old
+        # message blank.
+        sub = out_dir / "sub"
+        sub.mkdir()
+        _git(sub, "init")
+        _git(sub, "config", "user.email", "test@test.com")
+        _git(sub, "config", "user.name", "Test")
+        (sub / "a.txt").write_text("a\n")
+        _git(sub, "add", "-A")
+        _git(sub, "commit", "-m", "init")
+        _git(
+            tmp_git_repo,
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            str(sub),
+            "sub",
+        )
+        _git(tmp_git_repo, "commit", "-m", "add submodule")
+        (tmp_git_repo / "sub" / "a.txt").write_text("dirty\n")
+
+        assert create_scaffold_commit(tmp_git_repo) is None
+
+        assert "no changes added to commit" in caplog.text
+
     def test_failing_pre_commit_hook_does_not_block(
         self, tmp_git_repo: Path
     ) -> None:

--- a/tests/test_wip_scope.py
+++ b/tests/test_wip_scope.py
@@ -17,6 +17,7 @@ import pytest
 from mr_overkill.wip_scope import (
     SCAFFOLD_MESSAGE,
     create_scaffold_commit,
+    head_is_scaffold,
     is_in_head,
     merge_base,
     operation_in_progress,
@@ -345,6 +346,28 @@ class TestIsInHead:
         _git(tmp_git_repo, "reset", "--quiet", "--mixed", base)
 
         assert is_in_head(scaffold, tmp_git_repo) is False
+
+
+class TestHeadIsScaffold:
+    def test_a_leftover_scaffolding_commit_is_recognised(
+        self, tmp_git_repo: Path
+    ) -> None:
+        # What a run killed before its unwind leaves behind.
+        (tmp_git_repo / "feature.py").write_text("x = 1\n")
+        assert create_scaffold_commit(tmp_git_repo) is not None
+
+        assert head_is_scaffold(tmp_git_repo) is True
+
+    def test_an_ordinary_commit_is_not(self, tmp_git_repo: Path) -> None:
+        assert head_is_scaffold(tmp_git_repo) is False
+
+    def test_an_unwound_scaffold_is_not(self, tmp_git_repo: Path) -> None:
+        base = _git(tmp_git_repo, "rev-parse", "HEAD")
+        (tmp_git_repo / "feature.py").write_text("x = 1\n")
+        assert create_scaffold_commit(tmp_git_repo) is not None
+        _git(tmp_git_repo, "reset", "--quiet", "--mixed", base)
+
+        assert head_is_scaffold(tmp_git_repo) is False
 
 
 class TestSaveMetadata:

--- a/tests/test_wip_scope.py
+++ b/tests/test_wip_scope.py
@@ -18,6 +18,7 @@ from mr_overkill.wip_scope import (
     SCAFFOLD_MESSAGE,
     create_scaffold_commit,
     merge_base,
+    operation_in_progress,
     uncommitted_files,
     unwind,
     write_worktree_diff,
@@ -39,6 +40,11 @@ def _git(repo: Path, *args: str) -> str:
         ["git", *args], cwd=repo, capture_output=True, text=True, check=True
     )
     return result.stdout.strip()
+
+
+def _branch(repo: Path) -> str:
+    """The repo's initial branch name — 'main' or 'master' depending on git config."""
+    return _git(repo, "rev-parse", "--abbrev-ref", "HEAD")
 
 
 def _status(repo: Path) -> str:
@@ -89,12 +95,13 @@ class TestMergeBase:
 
     def test_unrelated_history_returns_none(self, tmp_git_repo: Path) -> None:
         # An orphan branch shares no history with HEAD at all.
+        original = _branch(tmp_git_repo)
         _git(tmp_git_repo, "checkout", "-q", "--orphan", "orphan")
         (tmp_git_repo / "other.txt").write_text("other\n")
         _git(tmp_git_repo, "add", "other.txt")
         _git(tmp_git_repo, "commit", "-m", "orphan root")
 
-        assert merge_base("master", tmp_git_repo) is None
+        assert merge_base(original, tmp_git_repo) is None
 
 
 class TestWriteWorktreeDiff:
@@ -247,6 +254,29 @@ class TestCreateScaffoldCommit:
         assert _status(tmp_git_repo) == ""
 
 
+class TestOperationInProgress:
+    def test_idle_repo(self, tmp_git_repo: Path) -> None:
+        assert operation_in_progress(tmp_git_repo) is None
+
+    def test_conflicted_merge_is_detected(self, tmp_git_repo: Path) -> None:
+        # Committing here would conclude the merge, and unwinding would then
+        # reset past it and drop MERGE_HEAD.
+        original = _branch(tmp_git_repo)
+        base = _git(tmp_git_repo, "rev-parse", "HEAD")
+        (tmp_git_repo / "conflict.txt").write_text("ours\n")
+        _git(tmp_git_repo, "add", "conflict.txt")
+        _git(tmp_git_repo, "commit", "-m", "ours")
+        _git(tmp_git_repo, "checkout", "-q", "-b", "theirs", base)
+        (tmp_git_repo / "conflict.txt").write_text("theirs\n")
+        _git(tmp_git_repo, "add", "conflict.txt")
+        _git(tmp_git_repo, "commit", "-m", "theirs")
+        subprocess.run(
+            ["git", "merge", original], cwd=tmp_git_repo, capture_output=True
+        )
+
+        assert operation_in_progress(tmp_git_repo) == "merge"
+
+
 class TestUnwind:
     def _scaffold_then_fix(self, repo: Path) -> tuple[str, str]:
         """Simulate a full run: park WIP, then commit an AI fix on top."""
@@ -317,13 +347,31 @@ class TestUnwind:
         assert not unwind(base, scaffold, out_dir, tmp_git_repo)
         assert _git(tmp_git_repo, "rev-parse", "HEAD") == head
 
-    def test_no_scaffold_recorded_still_resets(
+    def test_missing_scaffold_refuses(
         self, tmp_git_repo: Path, out_dir: Path
     ) -> None:
+        # Without the scaffolding commit there is no proof this is even the
+        # branch the run happened on.
         base = _git(tmp_git_repo, "rev-parse", "HEAD")
         (tmp_git_repo / "x.py").write_text("x = 1\n")
-        create_scaffold_commit(tmp_git_repo)
+        head = create_scaffold_commit(tmp_git_repo)
 
-        assert unwind(base, None, out_dir, tmp_git_repo)
-        assert _git(tmp_git_repo, "rev-parse", "HEAD") == base
-        assert not (out_dir / "wip-fixes.diff").exists()
+        assert not unwind(base, None, out_dir, tmp_git_repo)
+        assert _git(tmp_git_repo, "rev-parse", "HEAD") == head
+
+    def test_refuses_on_a_sibling_branch(
+        self, tmp_git_repo: Path, out_dir: Path
+    ) -> None:
+        """A sibling branch off the same base passes an ancestry test against
+        that base, so resetting on the strength of it would rewind the wrong
+        branch. Only the scaffolding commit identifies the right one."""
+        base, scaffold = self._scaffold_then_fix(tmp_git_repo)
+        _git(tmp_git_repo, "stash", "-u")
+        _git(tmp_git_repo, "checkout", "-q", "-b", "sibling", base)
+        (tmp_git_repo / "sibling.py").write_text("sibling = 1\n")
+        _git(tmp_git_repo, "add", "sibling.py")
+        _git(tmp_git_repo, "commit", "-m", "work on the sibling branch")
+        head = _git(tmp_git_repo, "rev-parse", "HEAD")
+
+        assert not unwind(base, scaffold, out_dir, tmp_git_repo)
+        assert _git(tmp_git_repo, "rev-parse", "HEAD") == head

--- a/tests/test_wip_scope.py
+++ b/tests/test_wip_scope.py
@@ -17,8 +17,10 @@ import pytest
 from mr_overkill.wip_scope import (
     SCAFFOLD_MESSAGE,
     create_scaffold_commit,
+    is_in_head,
     merge_base,
     operation_in_progress,
+    save_metadata,
     uncommitted_files,
     unwind,
     write_worktree_diff,
@@ -277,6 +279,38 @@ class TestOperationInProgress:
         assert operation_in_progress(tmp_git_repo) == "merge"
 
 
+class TestIsInHead:
+    def test_a_commit_on_the_branch_is_found(self, tmp_git_repo: Path) -> None:
+        (tmp_git_repo / "feature.py").write_text("x = 1\n")
+        scaffold = create_scaffold_commit(tmp_git_repo)
+        assert scaffold is not None
+
+        assert is_in_head(scaffold, tmp_git_repo) is True
+
+    def test_an_unwound_commit_is_not_found(self, tmp_git_repo: Path) -> None:
+        # This is what a resumed --wip run faces after a soft failure took the
+        # scaffolding down: the recorded SHA no longer exists in the history.
+        base = _git(tmp_git_repo, "rev-parse", "HEAD")
+        (tmp_git_repo / "feature.py").write_text("x = 1\n")
+        scaffold = create_scaffold_commit(tmp_git_repo)
+        assert scaffold is not None
+        _git(tmp_git_repo, "reset", "--quiet", "--mixed", base)
+
+        assert is_in_head(scaffold, tmp_git_repo) is False
+
+
+class TestSaveMetadata:
+    def test_it_replaces_a_dangling_scaffold_sha(self, tmp_path: Path) -> None:
+        # The re-park path calls this to overwrite the SHA a soft-failed run
+        # left behind; a stale one has no route back to the parked work.
+        log_dir = tmp_path / "logs"
+        save_metadata(log_dir, "b" * 40, "c" * 40)
+        save_metadata(log_dir, "b" * 40, "d" * 40)
+
+        assert (log_dir / "wip-base.txt").read_text() == "b" * 40
+        assert (log_dir / "wip-scaffold.txt").read_text() == "d" * 40
+
+
 class TestUnwind:
     def _scaffold_then_fix(self, repo: Path) -> tuple[str, str]:
         """Simulate a full run: park WIP, then commit an AI fix on top."""
@@ -324,6 +358,23 @@ class TestUnwind:
         fixes = (out_dir / "wip-fixes.diff").read_text()
         assert "def f() -> int:" in fixes
         assert "-def f():" in fixes
+
+    def test_an_empty_net_change_leaves_the_artefact_alone(
+        self, tmp_git_repo: Path, out_dir: Path
+    ) -> None:
+        # A run that scaffolds and then commits nothing has no net change to
+        # report, and writing the empty diff would replace an earlier
+        # attempt's record with a file claiming the loop changed nothing.
+        (out_dir / "wip-fixes.diff").write_text("--- an earlier attempt\n")
+        (tmp_git_repo / "feature.py").write_text("def f():\n    pass\n")
+        base = _git(tmp_git_repo, "rev-parse", "HEAD")
+        scaffold = create_scaffold_commit(tmp_git_repo)
+
+        assert unwind(base, scaffold, out_dir, tmp_git_repo)
+
+        assert (out_dir / "wip-fixes.diff").read_text() == (
+            "--- an earlier attempt\n"
+        )
 
     def test_is_idempotent(self, tmp_git_repo: Path, out_dir: Path) -> None:
         base, scaffold = self._scaffold_then_fix(tmp_git_repo)


### PR DESCRIPTION
## What

`overkill review-loop --wip` pulls uncommitted working-tree changes into the review scope. Until now the scope was always `git diff <target>...<current>` — committed work only. A dirty tree was rejected outright, and under `--dry-run` it was silently left *out* of scope while the run reviewed something else entirely.

## How

One flag, two mechanisms, picked by whether the run may commit:

| Command | Mechanism | Iterations | Commits left behind |
|---|---|---|---|
| `--wip --dry-run` | worktree diff → `.overkill/logs/wip.diff` | 1 | none |
| `--wip --no-auto-commit` | same | 1 | none |
| `--wip` | scaffolding commit, unwound at the end | up to `-n` | none |

Multiple iterations need commits — `_no_diff` and `diff_hash` read the commit graph, and `loop_engine.py` breaks after iteration 1 when `auto_commit` is off. So `--wip` parks the work in a throwaway commit, lets the loop run **completely unchanged** against it, then removes the scaffolding with `git reset --mixed`. Both paths end the same way: dirty tree, fixes applied, no commit added.

Pushing is disabled outright rather than made configurable — the scaffolding commit holds unfinished work.

Reuses `${REVIEW_SCOPE_NOTE}`, the marker commit-scope already added, so no new prompt files and no new `overkill init` requirement.

## Found by dogfooding

Running the mode against this repo caught a bug the unit tests could not: naming a gitignored path in an `:(exclude)` pathspec makes `git add` abort the whole operation *after* partially staging — and `.overkill/` is gitignored here. A fresh fixture repo has no `.gitignore`, so the tests were blind to it.

A `--wip --dry-run` review pass on the implementation then found five more, all real and all fixed in `58f91d0`: unwinding could rewind a *sibling* branch off the same base; scaffolding during a conflicted merge would have concluded the merge and made it unfinishable; resuming a no-commit run let the resume reset stash away the tree under review; a failed unwind still exited 0; and only the scaffolding commit skipped hooks, so the first fix commit would abort the loop in any repo with hooks that reject WIP.

## Tests

510 pass (+65). `tests/test_wip_scope.py` runs against real git throughout — every function here exists because of git behaviour that a mock would only confirm my assumptions about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)