### PR TITLE
chore: merge 0.9.0 review fixes into develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ Options:
   -t, --target <rev>       Target to diff against (default: develop). Accepts any
                            git revision, not just a branch name: a SHA, a tag, or
                            HEAD~5 all work, so you can review "everything since
-                           commit X" without opening a PR.
+                           commit X" without opening a PR. A revision that moves
+                           with HEAD is pinned to a SHA when the run starts, so
+                           the loop's own fix commits cannot shrink the range.
   --commit <rev>           Review an already-merged commit instead of the branch
                            diff. Creates a review/<sha>-<ts> branch off HEAD and
                            applies fixes there; no PR is created. <rev> is a single

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "overkill"
-version = "0.8.3"
+version = "0.9.0"
 description = "AI-powered code review loop — automates Codex/Gemini review + Claude fix cycles"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/mr_overkill/cli.py
+++ b/src/mr_overkill/cli.py
@@ -29,6 +29,29 @@ def _detect_current_branch() -> str:
     return result.stdout.strip() or "HEAD"
 
 
+def _symbolic_ref(rev: str) -> str:
+    """Full name of the ref *rev* resolves through, "" if it resolves without one."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--symbolic-full-name", rev],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def _is_stable_target(rev: str, current_branch: str) -> bool:
+    """Whether *rev* still means the same commit after the loop commits a fix.
+
+    A revision expression like ``HEAD~5`` names no ref at all and is measured
+    from HEAD every time it is read.  ``HEAD`` itself, and the branch the fix
+    commits land on, do name one — and it moves with every one of them.
+    Everything else — another branch, a tag, a bare SHA — stays put.
+    """
+    ref = _symbolic_ref(rev)
+    return bool(ref) and ref not in ("HEAD", f"refs/heads/{current_branch}")
+
+
 def _detect_pr_number(branch: str) -> str | None:
     """Detect open PR number for the given branch."""
     try:
@@ -604,6 +627,24 @@ def parse_review_loop_args(
         pr_number = None
     else:
         pr_number = _detect_pr_number(current_branch)
+        # The target is re-read on every iteration, so one that moves with
+        # HEAD slides forward as the loop's own fix commits land: the range
+        # shrinks off its oldest end and the commits that fall out of it stop
+        # being reviewed — silently, since the diff still looks healthy.  Pin
+        # it to what it means now.  A ref of its own keeps its name, which the
+        # reviewer prompt and the run report both read better for.  The
+        # --commit and --wip paths above pin their own targets already, and a
+        # resumed run inherits the pinning its first run did.
+        if (
+            auto_commit
+            and not dry_run
+            and restored_target is None
+            and not _is_stable_target(target, current_branch)
+        ):
+            pinned = resolve_commit(target)
+            if pinned is None:
+                parser.error(f"-t/--target: not a commit: {target!r}")
+            target = pinned
 
     # COMMIT_SCOPE_PUSH describes the auto-created review/* branch only; a
     # normal branch run must always push, or its first fix commit stays local.

--- a/src/mr_overkill/review_loop.py
+++ b/src/mr_overkill/review_loop.py
@@ -289,7 +289,11 @@ def _prepare_wip_scope(config: LoopConfig) -> bool:
     # Only on a fresh run: the re-park path above already proved HEAD is the
     # recorded base, and a leftover scaffolding commit *is* what it re-parks
     # onto, so refusing there would block the very resume this points at.
-    leftover = None if config.resume else wip_scope.find_scaffold_in_head()
+    leftover = (
+        None
+        if config.resume
+        else wip_scope.find_scaffold_in_head(target=config.target_branch)
+    )
     if leftover:
         logger.error(
             "Scaffolding commit %s is still in this branch's history — an "

--- a/src/mr_overkill/wip_scope.py
+++ b/src/mr_overkill/wip_scope.py
@@ -257,13 +257,34 @@ def create_scaffold_commit(cwd: Path | None = None) -> str | None:
     return sha or None
 
 
-#: How far back a fresh run looks for a leftover scaffolding commit.  Bounded
-#: so an ancient one nobody ever cleaned up cannot refuse every run forever.
+#: How far back a fresh run looks for a leftover scaffolding commit when there
+#: is no target to bound the search by.  Bounded so an ancient one nobody ever
+#: cleaned up cannot refuse every run forever.
 _SCAFFOLD_SEARCH_DEPTH = 25
 
 
+def _newest_scaffold(rev_args: list[str], cwd: Path | None) -> tuple[str | None, int]:
+    """Newest scaffolding commit among the commits *rev_args* selects.
+
+    Returns it alongside how many commits were looked at, because "no
+    scaffolding in this range" and "this range is empty" are different
+    answers to the caller: only the first one settles the question.
+    """
+    result = _run(["git", "log", "--format=%H %s", *rev_args], cwd)
+    if result.returncode != 0:
+        return None, 0
+    lines = [line for line in result.stdout.splitlines() if line.strip()]
+    for line in lines:
+        sha, _, subject = line.partition(" ")
+        if subject.strip() == SCAFFOLD_MESSAGE:
+            return sha.strip(), len(lines)
+    return None, len(lines)
+
+
 def find_scaffold_in_head(
-    cwd: Path | None = None, limit: int = _SCAFFOLD_SEARCH_DEPTH
+    cwd: Path | None = None,
+    limit: int = _SCAFFOLD_SEARCH_DEPTH,
+    target: str | None = None,
 ) -> str | None:
     """SHA of the newest leftover scaffolding commit reachable from HEAD.
 
@@ -278,15 +299,22 @@ def find_scaffold_in_head(
     fix commit — stranding both it and the earlier draft on the branch for
     good.  The scaffolding is never pushed and always unwound, so anything
     found here belongs to a run that died.
+
+    *target* bounds the search by history rather than by depth: an unpushed
+    commit is by definition one this branch does not share with the target, so
+    that range holds the leftovers of an interrupted run however long it ran —
+    a depth would lose the scaffolding of a run that got past *limit* fixes.
+    It also lets go of a scaffolding commit that somehow reached the target
+    branch, which a depth would keep tripping over forever.  A range that
+    comes back empty proves nothing (the target *is* HEAD, say), so that case
+    falls back to the bounded scan.
     """
-    result = _run(["git", "log", f"-n{limit}", "--format=%H %s", "HEAD"], cwd)
-    if result.returncode != 0:
-        return None
-    for line in result.stdout.splitlines():
-        sha, _, subject = line.partition(" ")
-        if subject.strip() == SCAFFOLD_MESSAGE:
-            return sha.strip()
-    return None
+    if target:
+        sha, seen = _newest_scaffold([f"{target}..HEAD"], cwd)
+        if seen:
+            return sha
+    sha, _ = _newest_scaffold([f"-n{limit}", "HEAD"], cwd)
+    return sha
 
 
 def is_in_head(commit: str, cwd: Path | None = None) -> bool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -14,6 +15,19 @@ from mr_overkill.cli import (
     parse_review_loop_args,
 )
 from mr_overkill.models import LoopConfig
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=True
+    )
+    return result.stdout.strip()
+
+
+def _commit(repo: Path, name: str) -> None:
+    (repo / name).write_text("x = 1\n")
+    _git(repo, "add", name)
+    _git(repo, "commit", "--quiet", "--no-verify", "-m", f"feat: add {name}")
 
 
 class TestResolveBool:
@@ -30,6 +44,54 @@ class TestResolveBool:
     def test_default(self) -> None:
         assert _resolve_bool(None, None, True) is True
         assert _resolve_bool(None, None, False) is False
+
+
+class TestTargetPinning:
+    """A committing run must review the same range from first fix to last."""
+
+    def _parse(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch, *argv: str
+    ) -> LoopConfig:
+        monkeypatch.chdir(repo)
+        with (
+            patch("mr_overkill.cli._load_rc_file", return_value={}),
+            patch("mr_overkill.cli._detect_current_branch", return_value="feat/x"),
+            patch("mr_overkill.cli._detect_pr_number", return_value=None),
+        ):
+            return parse_review_loop_args(list(argv))
+
+    def test_a_relative_target_is_pinned_to_a_sha(
+        self, tmp_git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # HEAD~1 is measured afresh every iteration, and the loop's own fix
+        # commits move HEAD: unpinned, the oldest commit in scope drops out.
+        _commit(tmp_git_repo, "a.py")
+        expected = _git(tmp_git_repo, "rev-parse", "HEAD~1")
+
+        config = self._parse(tmp_git_repo, monkeypatch, "-n", "2", "-t", "HEAD~1")
+
+        assert config.target_branch == expected
+
+    def test_a_branch_target_keeps_its_name(
+        self, tmp_git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A ref of its own does not move under the fix commits, and the name
+        # is what the reviewer prompt and the run report show.
+        branch = _git(tmp_git_repo, "rev-parse", "--abbrev-ref", "HEAD")
+
+        config = self._parse(tmp_git_repo, monkeypatch, "-n", "2", "-t", branch)
+
+        assert config.target_branch == branch
+
+    def test_a_dry_run_target_is_left_alone(
+        self, tmp_git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Nothing is committed, so nothing moves.
+        config = self._parse(
+            tmp_git_repo, monkeypatch, "-n", "1", "--dry-run", "-t", "HEAD~1"
+        )
+
+        assert config.target_branch == "HEAD~1"
 
 
 class TestLoadRcFile:

--- a/tests/test_wip_scope.py
+++ b/tests/test_wip_scope.py
@@ -446,6 +446,53 @@ class TestFindScaffoldInHead:
 
         assert find_scaffold_in_head(tmp_git_repo) is None
 
+    def test_a_scaffold_past_the_depth_limit_is_still_found(
+        self, tmp_git_repo: Path
+    ) -> None:
+        # A long interrupted run buries its scaffolding under one fix commit
+        # per iteration.  The target bounds the search by history instead, so
+        # the depth no longer decides whether the leftovers are seen.
+        base = _git(tmp_git_repo, "rev-parse", "HEAD")
+        (tmp_git_repo / "feature.py").write_text("x = 1\n")
+        scaffold = create_scaffold_commit(tmp_git_repo)
+        assert scaffold is not None
+        for i in range(3):
+            (tmp_git_repo / "feature.py").write_text(f"x = {i + 2}\n")
+            _git(tmp_git_repo, "add", "feature.py")
+            _git(
+                tmp_git_repo, "commit", "--quiet", "--no-verify",
+                "-m", f"fix(ai-review): apply iteration {i + 1} fixes [skip ci]",
+            )
+
+        assert find_scaffold_in_head(tmp_git_repo, limit=2) is None
+        assert find_scaffold_in_head(tmp_git_repo, limit=2, target=base) == scaffold
+
+    def test_a_scaffold_already_in_the_target_is_left_alone(
+        self, tmp_git_repo: Path
+    ) -> None:
+        # One that reached the target branch is history now, not a leftover
+        # this run has to refuse to build on — and a depth-bounded search
+        # would trip over it on every run from here on.
+        (tmp_git_repo / "feature.py").write_text("x = 1\n")
+        scaffold = create_scaffold_commit(tmp_git_repo)
+        assert scaffold is not None
+        (tmp_git_repo / "later.py").write_text("y = 1\n")
+        _git(tmp_git_repo, "add", "later.py")
+        _git(tmp_git_repo, "commit", "--quiet", "--no-verify", "-m", "feat: later work")
+
+        assert find_scaffold_in_head(tmp_git_repo, target=scaffold) is None
+
+    def test_an_empty_target_range_falls_back_to_the_depth_scan(
+        self, tmp_git_repo: Path
+    ) -> None:
+        # Running on the target branch itself leaves nothing to bound by, and
+        # an empty range is no proof the branch is clean.
+        (tmp_git_repo / "feature.py").write_text("x = 1\n")
+        scaffold = create_scaffold_commit(tmp_git_repo)
+        assert scaffold is not None
+
+        assert find_scaffold_in_head(tmp_git_repo, target="HEAD") == scaffold
+
 
 class TestForeignCommitsSince:
     def test_the_loops_own_fix_commits_are_not_foreign(

--- a/uv.lock
+++ b/uv.lock
@@ -247,7 +247,7 @@ wheels = [
 
 [[package]]
 name = "overkill"
-version = "0.8.3"
+version = "0.9.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Feeds the two fixes the 0.9.0 release review produced back into `develop`, ahead of merging #160 into `main`.

Merging the release branch itself rather than cherry-picking, so `develop` and `main` share the commits and the post-release sync stays a clean merge (same shape as #140 and #142).

## `fix(review-loop): keep a relative target from sliding under its own fixes`

**Pre-existing, and not part of either new mode.** The target is re-read on every iteration, so one measured from HEAD — `-t HEAD~5`, or the branch being worked on — moves forward with each fix commit the loop makes. The reviewed range shrinks off its oldest end and those commits silently stop being reviewed, while the diff still looks healthy enough for the convergence check to pass.

This is the usage 0.8.x documented (`-t` accepts any git rev, so you can review "everything since commit X"), so `develop` wants it regardless of the release.

Fixed by pinning the target to a SHA — but only for a revision that actually moves. A branch or tag of its own keeps its name, which the reviewer prompt and the run report both read better for.

## `fix(wip): bound the leftover-scaffolding search by history, not by depth`

An interrupted `--wip` run buries its scaffolding commit under one fix commit per iteration, so a long enough run pushed it past the 25-commit window the guard searched. A fresh run then saw a clean branch, parked the work in a second scaffold, and unwound only to the newer base — leaving the earlier draft committed on the branch, where it would surface in the next PR diff.

The scaffolding is never pushed, so it can only be among the commits the branch does not share with the target. That range catches an interrupted run of any length, and it also lets go of a scaffolding commit that somehow reached the target branch, which a depth would have tripped over on every run from then on.

## Also in this branch

`chore: bump version to 0.9.0` — comes along with the merge. `develop` is heading there anyway, and sharing it is what keeps the post-release `main` → `develop` sync down to the release merge commit.

## Verification

553 tests pass; ruff and mypy clean; CI green on 3.11 / 3.12 / 3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)